### PR TITLE
Automate Play Store deployment via GitHub Actions

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -1,0 +1,42 @@
+name: Publish to Google Play
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Build and publish release bundle
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_PLAY_TRACK: production
+      GOOGLE_PLAY_RELEASE_STATUS: completed
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode Play Store service account
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "${SERVICE_ACCOUNT_JSON}" ]; then
+            echo "The GOOGLE_PLAY_SERVICE_ACCOUNT_JSON secret is not configured." >&2
+            exit 1
+          fi
+          echo "${SERVICE_ACCOUNT_JSON}" | base64 --decode > "${{ runner.temp }}/service-account.json"
+
+      - name: Publish release bundle
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/service-account.json
+        run: ./gradlew publishReleaseBundle

--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ However, even if it theoretically would fully work in your browser and you don't
 **ErikrafT Drop for Android** would like to become a community project. I invite your participation through issues and pull requests! Also bug reports are very welcome! But note that this is **not** the right place to report bugs regarding the **ErikrafT Drop website** which occur independently of this app.
 
 ### Development
-If you want to help with development, this would be more than welcome! I am very glad about every pull request. Just fork the repo and start coding. However, if you plan to implement larger changes, please tell us in the [issue tracker](https://github.com/erikraft/Drop-Android/issues) before hacking on your great new feature. 
+If you want to help with development, this would be more than welcome! I am very glad about every pull request. Just fork the repo and start coding. However, if you plan to implement larger changes, please tell us in the [issue tracker](https://github.com/erikraft/Drop-Android/issues) before hacking on your great new feature.
+
+### Play Store automation
+This repository ships with a GitHub Actions workflow (`Publish to Google Play`) that automatically builds a release bundle and uploads it to the Google Play Store whenever changes are pushed to the `main` branch. To enable the workflow:
+
+1. Create a Google Cloud service account with access to the Google Play Developer API and download its JSON key.
+2. Base64 encode the JSON key file and store it as the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret in the repository settings.
+3. Adjust the default track (`production`) or release status (`completed`) by editing the environment variables in `.github/workflows/play-store-publish.yml` if needed.
+
+The workflow relies on the Gradle Play Publisher plugin and will run `./gradlew publishReleaseBundle` to upload the generated app bundle to the selected track.
 
 ## Other software
 ### Related software

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'checkstyle'
     id 'com.mikepenz.aboutlibraries.plugin'
+    id 'com.github.triplet.play'
 }
 
 android {
@@ -94,4 +95,14 @@ tasks.register('checkstyle', Checkstyle) {
 
 tasks.named('check') {
     dependsOn tasks.named('checkstyle')
+}
+
+def playServiceAccountPath = System.getenv("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")
+if (playServiceAccountPath != null && !playServiceAccountPath.isBlank()) {
+    play {
+        serviceAccountCredentials.set(file(playServiceAccountPath))
+        track.set(System.getenv("GOOGLE_PLAY_TRACK") ?: "production")
+        releaseStatus.set(System.getenv("GOOGLE_PLAY_RELEASE_STATUS") ?: "completed")
+        defaultToAppBundles.set(true)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.0'
+        classpath 'com.github.triplet.gradle:play-publisher:3.11.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary
- add the Gradle Play Publisher plugin so release bundles can be uploaded directly from CI
- create a GitHub Actions workflow that builds the release bundle and publishes it to Google Play on pushes to `main`
- document how to configure the required secret and customize the deployment workflow

## Testing
- not run (CI workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e195fc0240832a81c6494dda959500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured continuous integration to build and publish Android releases to Google Play with safeguards for missing credentials.
  * Integrated publishing tooling into the build system, enabling track and release status configuration for releases.
* **Documentation**
  * Added a “Play Store automation” section detailing how releases are built and published via the workflow, including setup steps and usage notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->