### PR TITLE
Add automation to publish releases to F-Droid

### DIFF
--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -1,0 +1,104 @@
+name: Publish to F-Droid
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: ${{ secrets.FDROID_SIGNING_KEY != '' && secrets.FDROID_KEY_ALIAS != '' && secrets.FDROID_KEYSTORE_PASS != '' && secrets.FDROID_KEY_PASS != '' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build release APK
+        run: |
+          chmod +x gradlew
+          ./gradlew clean assembleRelease
+
+      - name: Sign release APK
+        id: sign
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.FDROID_SIGNING_KEY }}
+          alias: ${{ secrets.FDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.FDROID_KEYSTORE_PASS }}
+          keyPassword: ${{ secrets.FDROID_KEY_PASS }}
+
+      - name: Extract version information
+        id: version
+        run: |
+          VERSION_NAME=$(grep 'versionName "' app/build.gradle | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/')
+          VERSION_CODE=$(grep 'versionCode' app/build.gradle | head -n 1 | sed -E 's/[^0-9]*([0-9]+).*/\1/')
+          echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version_code=${VERSION_CODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+          python3 -m pip install --user --upgrade fdroidserver
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Prepare F-Droid configuration
+        env:
+          FDROID_REPO_NAME: ${{ secrets.FDROID_REPO_NAME }}
+          FDROID_REPO_URL: ${{ secrets.FDROID_REPO_URL }}
+          FDROID_REPO_DESCRIPTION: ${{ secrets.FDROID_REPO_DESCRIPTION }}
+          FDROID_KEY_ALIAS: ${{ secrets.FDROID_KEY_ALIAS }}
+          FDROID_KEYSTORE_PASS: ${{ secrets.FDROID_KEYSTORE_PASS }}
+          FDROID_KEY_PASS: ${{ secrets.FDROID_KEY_PASS }}
+        run: |
+          mkdir -p fdroid/repo
+          : "${FDROID_REPO_NAME:=Drop self-hosted repo}"
+          : "${FDROID_REPO_URL:=https://example.com/fdroid}"
+          : "${FDROID_REPO_DESCRIPTION:=Self-hosted repository containing signed ErikrafT Drop builds.}"
+          export FDROID_REPO_NAME FDROID_REPO_URL FDROID_REPO_DESCRIPTION
+          envsubst < fdroid/config.yml.template > fdroid/config.yml
+
+      - name: Restore signing keystore for index
+        run: |
+          echo "${{ secrets.FDROID_SIGNING_KEY }}" | base64 --decode > fdroid/keystore.jks
+
+      - name: Stage metadata and APK
+        env:
+          VERSION_NAME: ${{ steps.version.outputs.version_name }}
+          VERSION_CODE: ${{ steps.version.outputs.version_code }}
+          SIGNED_APK: ${{ steps.sign.outputs.signedReleaseFile }}
+        run: |
+          sed -i "s/^CurrentVersion: .*/CurrentVersion: ${VERSION_NAME}/" fdroid/metadata/com.erikraft.drop.yml
+          sed -i "s/^CurrentVersionCode: .*/CurrentVersionCode: ${VERSION_CODE}/" fdroid/metadata/com.erikraft.drop.yml
+          rm -f fdroid/repo/com.erikraft.drop_*.apk
+          cp "${SIGNED_APK}" "fdroid/repo/com.erikraft.drop_${VERSION_CODE}.apk"
+
+      - name: Update F-Droid repository
+        run: |
+          cd fdroid
+          fdroid update --create-metadata --config config.yml
+
+      - name: Clean sensitive files
+        if: always()
+        run: |
+          rm -f fdroid/keystore.jks fdroid/config.yml
+
+      - name: Publish repository to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: fdroid/repo
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 !.idea/checkstyle-idea.xml
 *.iml
 *.lnk
+
+# fdroid workflow artifacts
+fdroid/keystore.jks
+fdroid/config.yml

--- a/README.md
+++ b/README.md
@@ -45,7 +45,59 @@ However, even if it theoretically would fully work in your browser and you don't
 **ErikrafT Drop for Android** would like to become a community project. I invite your participation through issues and pull requests! Also bug reports are very welcome! But note that this is **not** the right place to report bugs regarding the **ErikrafT Drop website** which occur independently of this app.
 
 ### Development
-If you want to help with development, this would be more than welcome! I am very glad about every pull request. Just fork the repo and start coding. However, if you plan to implement larger changes, please tell us in the [issue tracker](https://github.com/erikraft/Drop-Android/issues) before hacking on your great new feature. 
+If you want to help with development, this would be more than welcome! I am very glad about every pull request. Just fork the repo and start coding. However, if you plan to implement larger changes, please tell us in the [issue tracker](https://github.com/erikraft/Drop-Android/issues) before hacking on your great new feature.
+
+## Automated F-Droid publishing
+
+This repository ships with a GitHub Actions workflow that can turn every tagged
+release into a signed, self-hosted F-Droid repository. The workflow lives at
+`.github/workflows/fdroid-publish.yml` and performs the following tasks:
+
+1. builds the release variant of the app with Gradle;
+2. signs the APK with your provided keystore;
+3. refreshes the metadata contained in `fdroid/metadata/com.erikraft.drop.yml`;
+4. generates the F-Droid index with `fdroidserver`; and
+5. publishes the finished repository to the `gh-pages` branch so it can be
+   served via GitHub Pages.
+
+Enable GitHub Pages for the project and choose the `gh-pages` branch as source.
+After the first successful run the repository will be available at
+`https://<username>.github.io/Drop-Android/` (replace `<username>` with your
+GitHub handle). Add this URL inside the F-Droid client to install builds from
+the automated repository.
+
+### Required repository secrets
+
+The workflow depends on several GitHub secrets that are consumed both for
+signing the APK and for signing the repository index:
+
+| Secret | Purpose |
+| --- | --- |
+| `FDROID_SIGNING_KEY` | Base64 encoded keystore used to sign the APK and F-Droid index. |
+| `FDROID_KEY_ALIAS` | Alias of the key inside the keystore. |
+| `FDROID_KEYSTORE_PASS` | Password that unlocks the keystore. |
+| `FDROID_KEY_PASS` | Password for the private key. |
+
+You can create the Base64 string for the keystore by running
+`base64 -w0 my-release-key.jks`.
+
+### Optional secrets
+
+You can further customise the generated repository by defining the following
+secrets (defaults are used when they are not present):
+
+| Secret | Default |
+| --- | --- |
+| `FDROID_REPO_NAME` | `Drop self-hosted repo` |
+| `FDROID_REPO_URL` | `https://example.com/fdroid` |
+| `FDROID_REPO_DESCRIPTION` | `Self-hosted repository containing signed ErikrafT Drop builds.` |
+
+### Running the workflow
+
+The workflow runs automatically when a GitHub release is published and can be
+triggered manually from the Actions tab via the `workflow_dispatch` event. Once
+the required secrets are configured you can publish an updated build to F-Droid
+by pushing a release tag and creating a GitHub release.
 
 ## Other software
 ### Related software

--- a/fdroid/config.yml.template
+++ b/fdroid/config.yml.template
@@ -1,0 +1,12 @@
+# Template used by the fdroid-publish workflow to generate a runtime configuration.
+# Values are supplied via environment variables in the workflow before running
+# any F-Droid server commands.
+repo_name: "${FDROID_REPO_NAME}"
+repo_url: "${FDROID_REPO_URL}"
+repo_description: "${FDROID_REPO_DESCRIPTION}"
+repo_keyalias: "${FDROID_KEY_ALIAS}"
+keystore: keystore.jks
+keystorepass: "${FDROID_KEYSTORE_PASS}"
+keypass: "${FDROID_KEY_PASS}"
+make_current_version_link: false
+archive_older: 1

--- a/fdroid/metadata/com.erikraft.drop.yml
+++ b/fdroid/metadata/com.erikraft.drop.yml
@@ -1,0 +1,20 @@
+Categories:
+  - Internet
+  - System
+License: GPL-3.0-or-later
+SourceCode: https://github.com/erikraft/Drop-Android
+IssueTracker: https://github.com/erikraft/Drop-Android/issues
+Changelog: https://github.com/erikraft/Drop-Android/releases
+Donate: https://github.com/sponsors/erikraft
+Summary: Local file sharing with Drop
+Description: |-
+  ErikrafT Drop connects your Android devices with drop.erikraft.com so you can
+  send files, text snippets and clipboard contents across the local network
+  without configuring accounts or relying on the public Internet. The client is
+  open source, respects your privacy and is optimised for quick transfers between
+  phones, tablets and desktop browsers.
+AutoUpdateMode: None
+UpdateCheckMode: Tags
+CurrentVersion: 2.3.1
+CurrentVersionCode: 45
+Builds: []


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds, signs, and publishes a self-hosted F-Droid repository on tagged releases
- introduce an F-Droid config template and metadata to drive the publication process
- document the new automation and required secrets in the README and ignore transient workflow files

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e195dda4bc832aaa1b510c989e8bf7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automated publishing of releases to an F-Droid repository, with signed APKs and metadata hosted via GitHub Pages.
  - Initial F-Droid app metadata included, enabling discovery and updates via the repo.

- Documentation
  - Added guidance on F-Droid publishing, required secrets, enabling GitHub Pages, and how to consume the repository.

- Chores
  - Introduced a CI workflow to build, sign, stage, and publish releases to the F-Droid repo.
  - Updated ignore rules for sensitive F-Droid artifacts and added a configuration template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->