### PR TITLE
Add self-hosted F-Droid publication workflow

### DIFF
--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -1,0 +1,99 @@
+name: Publish to self-hosted F-Droid repo
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fdroid:
+    name: Build and publish F-Droid repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Determine app version
+        id: version
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          text = pathlib.Path('app/build.gradle').read_text()
+          name = re.search(r'versionName\s+"([^"]+)"', text).group(1)
+          code = re.search(r'versionCode\s+(\d+)', text).group(1)
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+              fh.write(f"version_name={name}\n")
+              fh.write(f"version_code={code}\n")
+          PY
+
+      - name: Prepare F-Droid workspace
+        run: |
+          mkdir -p fdroid/repo fdroid/icons
+          cp app/src/main/res/mipmap-xxxhdpi/ic_launcher.png fdroid/icons/com.erikraft.drop.png
+          cp "app/build/outputs/apk/release/erikraftdrop_v${{ steps.version.outputs.version_name }}.apk" \
+             "fdroid/repo/com.erikraft.drop_${{ steps.version.outputs.version_code }}.apk"
+
+      - name: Update F-Droid metadata
+        run: scripts/update_fdroid_metadata.py
+
+      - name: Install fdroidserver
+        run: |
+          python -m pip install --upgrade pip
+          pip install fdroidserver
+
+      - name: Write F-Droid config
+        env:
+          FDROID_REPO_URL: ${{ secrets.FDROID_REPO_URL }}
+          FDROID_REPO_NAME: ${{ secrets.FDROID_REPO_NAME }}
+          FDROID_REPO_DESCRIPTION: ${{ secrets.FDROID_REPO_DESCRIPTION }}
+          FDROID_REPO_ADDRESS: ${{ secrets.FDROID_REPO_ADDRESS }}
+          FDROID_KEY_ALIAS: ${{ secrets.FDROID_KEY_ALIAS }}
+          FDROID_KEY_PASSWORD: ${{ secrets.FDROID_KEY_PASSWORD }}
+          FDROID_KEYSTORE_PASSWORD: ${{ secrets.FDROID_KEYSTORE_PASSWORD }}
+        run: scripts/write_fdroid_config.sh
+
+      - name: Decode F-Droid keystore
+        env:
+          FDROID_KEYSTORE_BASE64: ${{ secrets.FDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$FDROID_KEYSTORE_BASE64" | base64 --decode > fdroid/keystore.jks
+
+      - name: Build repository index
+        run: |
+          cd fdroid
+          fdroid update --create-metadata --pretty
+
+      - name: Publish F-Droid repo branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: fdroid/repo
+          publish_branch: fdroid
+          force_orphan: true
+
+      - name: Clean sensitive files
+        if: always()
+        run: |
+          rm -f fdroid/keystore.jks fdroid/config.yml

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ This repository ships with a GitHub Actions workflow (`Publish to Google Play`) 
 
 The workflow relies on the Gradle Play Publisher plugin and will run `./gradlew publishReleaseBundle` to upload the generated app bundle to the selected track.
 
+### Self-hosted F-Droid automation
+The project also includes a workflow (`Publish to self-hosted F-Droid repo`) that prepares an F-Droid compatible repository whenever a GitHub release is published (you can also trigger it manually through the *Actions* tab). The workflow builds the signed APK, updates the metadata under `fdroid/`, generates the F-Droid index using [`fdroidserver`](https://gitlab.com/fdroid/fdroidserver), and publishes the result to the `fdroid` branch which can be served through GitHub Pages or any static hosting provider.
+
+To enable the workflow:
+
+1. Base64-encode the keystore that is used to sign production releases and save it as the `FDROID_KEYSTORE_BASE64` secret.
+2. Add the passwords and alias of that keystore as repository secrets: `FDROID_KEYSTORE_PASSWORD`, `FDROID_KEY_PASSWORD`, and `FDROID_KEY_ALIAS`.
+3. (Optional) Provide custom repository metadata by defining the secrets `FDROID_REPO_URL`, `FDROID_REPO_NAME`, `FDROID_REPO_DESCRIPTION`, and `FDROID_REPO_ADDRESS`. Default values are used when they are not supplied.
+4. Enable GitHub Pages for the repository (or configure another static host) to serve the contents of the `fdroid` branch so that F-Droid clients can consume the index.
+
+After the first successful run you will have a fully automated, self-hosted F-Droid catalogue that mirrors the signed releases from this repository.
+
 ## Other software
 ### Related software
 - ErikrafT Drop Web Extension for desktop platforms: [ErikrafT Drop Web Extension](https://github.com/erikraft/Drop/tree/master/Browser%20Extension)

--- a/fdroid/.gitignore
+++ b/fdroid/.gitignore
@@ -1,0 +1,4 @@
+repo/
+config.yml
+keystore.jks
+tmp/

--- a/fdroid/metadata/com.erikraft.drop.yml
+++ b/fdroid/metadata/com.erikraft.drop.yml
@@ -1,0 +1,27 @@
+Categories:
+  - Internet
+  - Multimedia
+License: GPL-3.0-only
+SourceCode: https://github.com/erikraft/Drop-Android
+IssueTracker: https://github.com/erikraft/Drop-Android/issues
+Changelog: https://github.com/erikraft/Drop-Android/releases
+Donate: https://github.com/sponsors/erikraft
+Liberapay: https://liberapay.com/ErikrafT/
+Name: ErikrafT Drop
+Summary: Local network file sharing client for ErikrafT Drop
+Description: |-
+  ErikrafT Drop for Android is the companion client for the open source
+  ErikrafT Drop web service. It streamlines sending and receiving files over
+  your local network without any external cloud service. Share content
+  directly from other applications, keep the connection private on your own
+  devices, and benefit from an interface that is optimised for daily use.
+
+  This metadata is used for the self-hosted F-Droid repository that is built
+  from GitHub Actions and contains the exact APKs produced from this
+  repository. Releases are signed with the same keystore as the Play Store
+  build so updates will install smoothly.
+CurrentVersion: 2.3.1
+CurrentVersionCode: 45
+AutoUpdateMode: None
+
+# Git commit: 8da7fd8

--- a/scripts/update_fdroid_metadata.py
+++ b/scripts/update_fdroid_metadata.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Update the self-hosted F-Droid metadata to match the Gradle version."""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+GRADLE_FILE = ROOT / "app" / "build.gradle"
+METADATA_FILE = ROOT / "fdroid" / "metadata" / "com.erikraft.drop.yml"
+
+VERSION_CODE_PATTERN = re.compile(r"versionCode\s+(\d+)")
+VERSION_NAME_PATTERN = re.compile(r'versionName\s+"([^"]+)"')
+
+
+def extract_versions() -> tuple[str, str]:
+    """Read versionCode and versionName from the Gradle build file."""
+    text = GRADLE_FILE.read_text(encoding="utf-8")
+    version_code_match = VERSION_CODE_PATTERN.search(text)
+    version_name_match = VERSION_NAME_PATTERN.search(text)
+
+    if not version_code_match:
+        raise SystemExit("Could not locate versionCode in app/build.gradle")
+    if not version_name_match:
+        raise SystemExit("Could not locate versionName in app/build.gradle")
+
+    return version_name_match.group(1), version_code_match.group(1)
+
+
+def get_commit_sha() -> str:
+    """Return the short SHA of the current commit for traceability."""
+    try:
+        sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=ROOT)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
+        raise SystemExit("Failed to query git commit SHA") from exc
+    return sha.decode().strip()
+
+
+def update_metadata(version_name: str, version_code: str, sha: str) -> None:
+    text = METADATA_FILE.read_text(encoding="utf-8")
+
+    replacements = {
+        r"(?m)^CurrentVersion: .+$": f"CurrentVersion: {version_name}",
+        r"(?m)^CurrentVersionCode: .+$": f"CurrentVersionCode: {version_code}",
+        r"(?m)^# Git commit: .+$": f"# Git commit: {sha}",
+    }
+
+    for pattern, replacement in replacements.items():
+        if re.search(pattern, text):
+            text = re.sub(pattern, replacement, text)
+        else:  # pragma: no cover - metadata initially missing comment, add it
+            if "# Git commit:" in replacement:
+                text = text.rstrip() + f"\n# Git commit: {sha}\n"
+
+    METADATA_FILE.write_text(text, encoding="utf-8")
+
+
+def main() -> None:
+    version_name, version_code = extract_versions()
+    sha = get_commit_sha()
+    update_metadata(version_name, version_code, sha)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/write_fdroid_config.sh
+++ b/scripts/write_fdroid_config.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Generate the fdroid/config.yml file using repository metadata and secrets.
+set -euo pipefail
+
+REPO_URL=${FDROID_REPO_URL:-"https://<username>.github.io/Drop-Android/fdroid/repo"}
+REPO_NAME=${FDROID_REPO_NAME:-"ErikrafT Drop self-hosted repo"}
+REPO_DESCRIPTION=${FDROID_REPO_DESCRIPTION:-"Automated builds published from GitHub Actions."}
+REPO_ADDRESS=${FDROID_REPO_ADDRESS:-""}
+KEY_ALIAS=${FDROID_KEY_ALIAS:?"FDROID_KEY_ALIAS secret not set"}
+
+cat > fdroid/config.yml <<CONFIG
+repo_url: ${REPO_URL}
+repo_name: ${REPO_NAME}
+repo_description: ${REPO_DESCRIPTION}
+repo_address: ${REPO_ADDRESS}
+repo_icon: icons/com.erikraft.drop.png
+keystore: keystore.jks
+repo_keyalias: ${KEY_ALIAS}
+keypass: ${FDROID_KEY_PASSWORD:?"FDROID_KEY_PASSWORD secret not set"}
+keystorepass: ${FDROID_KEYSTORE_PASSWORD:?"FDROID_KEYSTORE_PASSWORD secret not set"}
+make_current_version_link: true
+CONFIG


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the signed APK, generates the F-Droid index, and pushes it to a dedicated branch when a release is published
- add reusable scripts and metadata to keep the self-hosted F-Droid repository in sync with the Gradle version information
- document the required secrets and setup steps for enabling the automation in the README

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e307d56898832aaf26962cdaf7c8e6