### PR TITLE
Ensure APK is built as Drop-Android.apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         versionName "2.3.1"
         applicationVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "erikraftdrop_v${defaultConfig.versionName}.apk"
+                outputFileName = "Drop-Android.apk"
             }
         }
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- set the generated APK filename to Drop-Android.apk for all build variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e422e0e1e4832a837ba31bcc042edd