### PR TITLE
Update onboarding server descriptions for ErikrafT Drop

### DIFF
--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">اكتمل</string>
     <string name="onboarding_choose_server">اختر عنوان الخادم</string>
     <string name="onboarding_choose_server_short">اختر الخادم</string>
-    <string name="onboarding_choose_server_description">هذا التطبيق هو عميل مُحسَّن لتطبيقات الويب Snaplop و PairDrop.\nاختر واحدة من الأمثلة التالية أو حدد عنوان URL مخصص للاتصال به.\n\nملاحظة: يجب عليك اختيار نفس الرابط على جميع الأجهزة.</string>
+    <string name="onboarding_choose_server_description">هذا التطبيق هو عميل مُحسَّن لتطبيقات الويب ErikrafT Drop و PairDrop.\nاختر واحدة من الأمثلة التالية أو حدد عنوان URL مخصص للاتصال به.\n\nملاحظة: يجب عليك اختيار نفس الرابط على جميع الأجهزة.</string>
     <string name="onboarding_storage_permission">إذن التخزين</string>
     <string name="onboarding_storage_permission_description">هذا التطبيق هو أداة مشاركة للملفات. لذلك، إذن التخزين مطلوب لاستخدامه.</string>
     <string name="onboarding_server_pairdrop_summary">(موصى به)\nميزة الاقتران ، نقل الإنترنت والتركيز على الاستقرار.</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">finalitza</string>
     <string name="onboarding_choose_server">Trieu una adreça del servidor</string>
     <string name="onboarding_choose_server_short">trieu el servidor</string>
-    <string name="onboarding_choose_server_description">Aquesta aplicació és un client optimitzat per a les aplicacions web Snapdrop i PairDrop.\nTrieu una de les següents instàncies o especifiqueu un URL personalitzat per connectar-vos.\n\nNota: Heu de triar el mateix URL en tots els dispositius.</string>
+    <string name="onboarding_choose_server_description">Aquesta aplicació és un client optimitzat per a les aplicacions web ErikrafT Drop i PairDrop.\nTrieu una de les següents instàncies o especifiqueu un URL personalitzat per connectar-vos.\n\nNota: Heu de triar el mateix URL en tots els dispositius.</string>
     <string name="onboarding_storage_permission">Permís d\'emmagatzematge</string>
     <string name="onboarding_storage_permission_description">Aquesta aplicació és una utilitat per compartir fitxers. Per tant, es requereix el permís d\'emmagatzematge per poder utilitzar-la.</string>
     <string name="onboarding_server_pairdrop_summary">(recomanat)\nFunció d\'emparellament, transferència per Internet i enfocat en l\'estabilitat.</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">dokončit</string>
     <string name="onboarding_choose_server">Vyberte adresu serveru</string>
     <string name="onboarding_choose_server_short">vybrat server</string>
-    <string name="onboarding_choose_server_description">Tato aplikace je optimalizovaným klientem pro webové aplikace Snapdrop a PairDrop.\nVyberte jednu z následujících instancí nebo zadejte vlastní adresu URL pro připojení.\n\nPoznámka: Musíte vybrat stejnou adresu URL na všech zařízeních.</string>
+    <string name="onboarding_choose_server_description">Tato aplikace je optimalizovaným klientem pro webové aplikace ErikrafT Drop a PairDrop.\nVyberte jednu z následujících instancí nebo zadejte vlastní adresu URL pro připojení.\n\nPoznámka: Musíte vybrat stejnou adresu URL na všech zařízeních.</string>
     <string name="onboarding_storage_permission">Oprávnění úložiště</string>
     <string name="onboarding_storage_permission_description">Tato aplikace je nástroj pro sdílení souborů. Proto je vyžadováno oprávnění pro její používání.</string>
     <string name="onboarding_server_pairdrop_summary">(doporučeno)\nPárování, internetový přenos a zaměření na stabilitu.</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">fertigstellen</string>
     <string name="onboarding_choose_server">Serveradresse wählen</string>
     <string name="onboarding_choose_server_short">Server wählen</string>
-    <string name="onboarding_choose_server_description">Diese App ist ein optimierter Client für die Webanwendungen Snapdrop und PairDrop.\nWählen Sie eine der folgenden Instanzen oder geben Sie eine benutzerdefinierte URL an, mit der Sie sich verbinden möchten.\n\nHinweis: Sie müssen auf allen Geräten die gleiche URL wählen.</string>
+    <string name="onboarding_choose_server_description">Diese App ist ein optimierter Client für die Webanwendungen ErikrafT Drop und PairDrop.\nWählen Sie eine der folgenden Instanzen oder geben Sie eine benutzerdefinierte URL an, mit der Sie sich verbinden möchten.\n\nHinweis: Sie müssen auf allen Geräten die gleiche URL wählen.</string>
     <string name="onboarding_storage_permission">Speicherberechtigung</string>
     <string name="onboarding_storage_permission_description">Diese App ist ein Datei-Freigabe-Programm. Daher ist die Speicher-Berechtigung erforderlich, um funktionieren zu können.</string>
     <string name="onboarding_server_pairdrop_summary">(empfohlen)\nKopplungsfunktion, Internet-Übertragung und Fokus auf Stabilität.</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">ολοκλήρωση</string>
     <string name="onboarding_choose_server">Επιλέξτε διεύθυνση διακομιστή</string>
     <string name="onboarding_choose_server_short">επιλέξτε διακομιστή</string>
-    <string name="onboarding_choose_server_description">Αυτή η εφαρμογή είναι ένας βελτιστοποιημένος client για τις web εφαρμογές Snapdrop και PairDrop.\nΕπιλέξτε μία από τις ακόλουθες επιλογές ή καθορίστε μια προσαρμοσμένη διεύθυνση URL για να συνδεθίιτε.\n\nΣημείωση: Πρέπει να επιλέξετε το ίδιο URL σε όλες τις συσκευές.</string>
+    <string name="onboarding_choose_server_description">Αυτή η εφαρμογή είναι ένας βελτιστοποιημένος client για τις web εφαρμογές ErikrafT Drop και PairDrop.\nΕπιλέξτε μία από τις ακόλουθες επιλογές ή καθορίστε μια προσαρμοσμένη διεύθυνση URL για να συνδεθίιτε.\n\nΣημείωση: Πρέπει να επιλέξετε το ίδιο URL σε όλες τις συσκευές.</string>
     <string name="onboarding_storage_permission">Άδεια αποθήκευσης</string>
     <string name="onboarding_storage_permission_description">Αυτή η εφαρμογή είναι ένα πρόγραμμα κοινής χρήσης αρχείων. Ως εκ τούτου, απαιτείται άδεια αποθήκευσης για να μπορεί να χρησιμοποιηθεί.</string>
     <string name="onboarding_server_pairdrop_summary">(συνιστάται)\nΛειτουργία σύζευξης, μεταφορά μέσω διαδικτύου με στόχο τη σταθερότητα.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminar</string>
     <string name="onboarding_choose_server">Elige un servidor</string>
     <string name="onboarding_choose_server_short">elegir servidor</string>
-    <string name="onboarding_choose_server_description">Esta aplicación es un cliente optimizado para las aplicaciones web Snapdrop y PairDrop.\nElige una de las siguientes instancias o especifica una url personalizada a la que conectarse.\n\nNota: Tienes que elegir la misma URL en todos los dispositivos.</string>
+    <string name="onboarding_choose_server_description">Esta aplicación es un cliente optimizado para las aplicaciones web ErikrafT Drop y PairDrop.\nElige una de las siguientes instancias o especifica una url personalizada a la que conectarse.\n\nNota: Tienes que elegir la misma URL en todos los dispositivos.</string>
     <string name="onboarding_storage_permission">Permiso de almacenamiento</string>
     <string name="onboarding_storage_permission_description">Esta aplicación es una utilidad para compartir archivos. Por lo tanto, el permiso de almacenamiento es necesario para usarla.</string>
     <string name="onboarding_server_pairdrop_summary">(recomendado)\nFunción de emparejamiento, transferencia por Internet y enfoque en estabilidad.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminer</string>
     <string name="onboarding_choose_server">Choisir une adresse de serveur</string>
     <string name="onboarding_choose_server_short">Choisir le serveur</string>
-    <string name="onboarding_choose_server_description">Cette application est un client optimisé pour les applications web Snapdrop et PairDrop.\nChoisissez l\'une des instances suivantes ou spécifiez un URL personnalisé à laquelle vous devez vous connecter.\n\nNote : Vous devez choisir le même URL sur tous les appareils.</string>
+    <string name="onboarding_choose_server_description">Cette application est un client optimisé pour les applications web ErikrafT Drop et PairDrop.\nChoisissez l\'une des instances suivantes ou spécifiez un URL personnalisé à laquelle vous devez vous connecter.\n\nNote : Vous devez choisir le même URL sur tous les appareils.</string>
     <string name="onboarding_storage_permission">Autorisation d\'accès au stockage</string>
     <string name="onboarding_storage_permission_description">Cette application est un utilitaire de partage de fichiers. Par conséquent, une autorisation de stockage est nécessaire pour l\'utiliser.</string>
     <string name="onboarding_server_pairdrop_summary">(recommandé)\nFonctionnalité d\'appairage, transfert par internet et priorité à la stabilité.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">selesai</string>
     <string name="onboarding_choose_server">Pilih alamat server</string>
     <string name="onboarding_choose_server_short">pilih server</string>
-    <string name="onboarding_choose_server_description">Aplikasi ini adalah klien yang dioptimalkan untuk aplikasi web Snapdrop dan PairDrop.\nPilih salah satu dari beberapa opsi berikut atau tentukan url khusus agar dapat tersambung.\n\nCatatan: Anda harus menggunakan URL yang sama di semua perangkat.</string>
+    <string name="onboarding_choose_server_description">Aplikasi ini adalah klien yang dioptimalkan untuk aplikasi web ErikrafT Drop dan PairDrop.\nPilih salah satu dari beberapa opsi berikut atau tentukan url khusus agar dapat tersambung.\n\nCatatan: Anda harus menggunakan URL yang sama di semua perangkat.</string>
     <string name="onboarding_storage_permission">Izin penyimpanan</string>
     <string name="onboarding_storage_permission_description">Aplikasi ini adalah aplikasi berbagi file. Oleh karena itu, izin penyimpanan diperlukan untuk bisa digunakan.</string>
     <string name="onboarding_server_pairdrop_summary">(disarankan)\nFitur pairing, transfer internet dan fokus pada kestabilan.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -9,7 +9,7 @@
     <string name="onboarding_button_grant">concedi l\'autorizzazione</string>
     <string name="onboarding_button_finish">fine</string>
     <string name="onboarding_choose_server">Scegli un indirizzo del server</string>
-    <string name="onboarding_choose_server_description">Questa app è un client ottimizzato per le applicazioni web Snapdrop e PairDrop.\nScegli una delle seguenti istanze o specifica un URL personalizzato a cui connettersi.\n\nNota: Devi scegliere lo stesso URL su tutti i dispositivi.</string>
+    <string name="onboarding_choose_server_description">Questa app è un client ottimizzato per le applicazioni web ErikrafT Drop e PairDrop.\nScegli una delle seguenti istanze o specifica un URL personalizzato a cui connettersi.\n\nNota: Devi scegliere lo stesso URL su tutti i dispositivi.</string>
     <string name="onboarding_storage_permission">Autorizzazione di archiviazione</string>
     <string name="onboarding_storage_permission_description">Questa app è un\'utilità di condivisione di file. Pertanto, è richiesta l\'autorizzazione di archiviazione per utilizzarla.</string>
     <string name="onboarding_server_pairdrop_summary">(raccomandato)\nFunzionalità di collegamento, trasferimento internet e si concentra sulla stabilità.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -10,7 +10,7 @@
     <string name="onboarding_button_finish">完了</string>
     <string name="onboarding_choose_server">サーバー選択</string>
     <string name="onboarding_choose_server_short">サーバー選択</string>
-    <string name="onboarding_choose_server_description">このアプリはウェブアプリのSnapdropとPairDropに対応しています。\n以下のサーバーを選択するか、カスタムサーバーのURLを入力してください。\n\n注意: すべてのデバイスで同じサーバーに接続する必要があります。</string>
+    <string name="onboarding_choose_server_description">このアプリはウェブアプリのErikrafT DropとPairDropに対応しています。\n以下のサーバーを選択するか、カスタムサーバーのURLを入力してください。\n\n注意: すべてのデバイスで同じサーバーに接続する必要があります。</string>
     <string name="onboarding_storage_permission">ストレージ権限</string>
     <string name="onboarding_storage_permission_description">このアプリはファイル共有ツールです。そのため、ストレージへのアクセス許可が必要です。</string>
     <string name="onboarding_server_pairdrop_summary">(推奨)\nペアリングやインターネット上での転送機能があり、安定しています。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">완료</string>
     <string name="onboarding_choose_server">서버 주소를 선택하세요</string>
     <string name="onboarding_choose_server_short">서버 선택</string>
-    <string name="onboarding_choose_server_description">이 애플리케이션은 Snapdrop과 PairDrop 웹 앱에 대응되는 최적화된 클라이언트 입니다.\n다음 중 하나의 인스턴스를 고르거나, 연결할 커스텀 URL을 입력하세요.\n\n메모: 사용할 모든 기기가 같은 URL에 연결되어야 합니다.</string>
+    <string name="onboarding_choose_server_description">이 애플리케이션은 ErikrafT Drop과 PairDrop 웹 앱에 대응되는 최적화된 클라이언트 입니다.\n다음 중 하나의 인스턴스를 고르거나, 연결할 커스텀 URL을 입력하세요.\n\n메모: 사용할 모든 기기가 같은 URL에 연결되어야 합니다.</string>
     <string name="onboarding_storage_permission">저장소 권한</string>
     <string name="onboarding_storage_permission_description">이 앱은 파일 공유 유틸리티입니다. 파일에 접근하기 위해 저장소 접근 권한이 필요합니다.</string>
     <string name="onboarding_server_pairdrop_summary">(추천)\n페어링 기능, 인터넷을 통한 전송 그리고 더 높은 안정성.</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">voltooien</string>
     <string name="onboarding_choose_server">Kies een serveradres</string>
     <string name="onboarding_choose_server_short">kies een server</string>
-    <string name="onboarding_choose_server_description">Deze app is een geoptimaliseerde client voor de webapps Snapdrop en PairDrop.\nKies een van de volgende instanties of specificeer een aangepaste url om verbinding mee te maken.\n\nOpmerking: Kies dezelfde URL op alle apparaten.</string>
+    <string name="onboarding_choose_server_description">Deze app is een geoptimaliseerde client voor de webapps ErikrafT Drop en PairDrop.\nKies een van de volgende instanties of specificeer een aangepaste url om verbinding mee te maken.\n\nOpmerking: Kies dezelfde URL op alle apparaten.</string>
     <string name="onboarding_storage_permission">Toegang tot bestanden</string>
     <string name="onboarding_storage_permission_description">Deze app is bedoeld voor het delen van bestanden. Daarom is toestemming tot bestanden vereist om deze te gebruiken.</string>
     <string name="onboarding_server_pairdrop_summary">(aanbevolen)\nKoppeling functie, overdracht via internet en focus op stabiliteit.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">zakończ</string>
     <string name="onboarding_choose_server">Wybierz adres serwera</string>
     <string name="onboarding_choose_server_short">wybierz serwer</string>
-    <string name="onboarding_choose_server_description">Ta aplikacja jest zoptymalizowanym klientem aplikacji webowych Snapdrop i PairDrop.\nWybierz jedną z następujących instancji lub określ niestandardowy adres url do połączenia\n\nUwaga: musisz wybrać ten sam URL na wszystkich urządzeniach.</string>
+    <string name="onboarding_choose_server_description">Ta aplikacja jest zoptymalizowanym klientem aplikacji webowych ErikrafT Drop i PairDrop.\nWybierz jedną z następujących instancji lub określ niestandardowy adres url do połączenia\n\nUwaga: musisz wybrać ten sam URL na wszystkich urządzeniach.</string>
     <string name="onboarding_storage_permission">Uprawnienia do przechowywania danych</string>
     <string name="onboarding_storage_permission_description">Ta aplikacja jest narzędziem udostępniania plików. W związku z tym wymagane jest pozwolenie na przechowywanie plików, aby z niej korzystać.</string>
     <string name="onboarding_server_pairdrop_summary">(zalecane)\nFunkcja parowania, transfer Internetu i koncentracja na stabilności.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminar</string>
     <string name="onboarding_choose_server">Escolha o endereço do servidor</string>
     <string name="onboarding_choose_server_short">escolher servidor</string>
-    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o Snapdrop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma url personalizada para se conectar.\n\nNota: Você tem que escolher a mesma URL em todos os dispositivos.</string>
+    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o ErikrafT Drop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma url personalizada para se conectar.\n\nNota: Você tem que escolher a mesma URL em todos os dispositivos.</string>
     <string name="onboarding_storage_permission">Permissão de armazenamento</string>
     <string name="onboarding_storage_permission_description">Este aplicativo é usado para compartilhamento de arquivos. Portanto, a permissão de armazenamento é necessária para usá-lo.</string>
     <string name="onboarding_server_pairdrop_summary">(recomendado)\nrecurso de emparelhamento, transferência de internet e foco na estabilidade.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -9,7 +9,7 @@
     <string name="onboarding_button_grant">Acordă permisiuni</string>
     <string name="onboarding_button_finish">Finalizare</string>
     <string name="onboarding_choose_server">Alege o adresă de server</string>
-    <string name="onboarding_choose_server_description">Această aplicație este un client optimizat pentru aplicația web Snapdrop și PairDrop.\nAlege una dintre următoarele instanțe sau specifică un URL personalizat la care să te conectezi.\n\nNotă: Trebuie să alegeți același URL pe toate dispozitivele.</string>
+    <string name="onboarding_choose_server_description">Această aplicație este un client optimizat pentru aplicația web ErikrafT Drop și PairDrop.\nAlege una dintre următoarele instanțe sau specifică un URL personalizat la care să te conectezi.\n\nNotă: Trebuie să alegeți același URL pe toate dispozitivele.</string>
     <string name="onboarding_storage_permission">Permisiuni pentru stocare</string>
     <string name="onboarding_storage_permission_description">Această aplicație este pentru partajări. De aceea sunt necesare permisiuni pentru stocare.</string>
     <string name="onboarding_server_pairdrop_summary">(recomandat)\nFuncția de asociere, transfer internet și concentrare asupra stabilității.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">Завершить</string>
     <string name="onboarding_choose_server">Выберите адрес сервера</string>
     <string name="onboarding_choose_server_short">Выберите сервер</string>
-    <string name="onboarding_choose_server_description">Это приложение оптимизировано для веб-приложений Snapdrop и PairDrop.\nВыберите один из следующих экземпляров или укажите пользовательский URL для подключения.\n\nПримечание: вы должны выбрать один и тот же URL на всех устройствах.</string>
+    <string name="onboarding_choose_server_description">Это приложение оптимизировано для веб-приложений ErikrafT Drop и PairDrop.\nВыберите один из следующих экземпляров или укажите пользовательский URL для подключения.\n\nПримечание: вы должны выбрать один и тот же URL на всех устройствах.</string>
     <string name="onboarding_storage_permission">Разрешение на работу с файлами</string>
     <string name="onboarding_storage_permission_description">Это приложение является утилитой для обмена файлами. Поэтому для его использования требуется разрешение на работу с файлами.</string>
     <string name="onboarding_server_pairdrop_summary">(Рекомендуется)\nВозможность сопряжения, интернет-передача и фокус на стабильности.</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">dokončiť</string>
     <string name="onboarding_choose_server">Vyberte adresu serveru</string>
     <string name="onboarding_choose_server_short">vybrať server</string>
-    <string name="onboarding_choose_server_description">Táto aplikácia je optimalizovaný klient pre webové aplikácie Snapdrop a PairDrop.\nVyberte si jednu z nasledujúcich inštancií alebo špecifikuje vlastnú url na pripojenie.\n\nPoznámka: Musíte si vybrať rovnakú URL na všetkých zariadeniach.</string>
+    <string name="onboarding_choose_server_description">Táto aplikácia je optimalizovaný klient pre webové aplikácie ErikrafT Drop a PairDrop.\nVyberte si jednu z nasledujúcich inštancií alebo špecifikuje vlastnú url na pripojenie.\n\nPoznámka: Musíte si vybrať rovnakú URL na všetkých zariadeniach.</string>
     <string name="onboarding_storage_permission">Povolenie prístupu k súborom</string>
     <string name="onboarding_storage_permission_description">Táto aplikácia je nástroj na zdieľanie súborov. Preto je pre použitie vyžadované povolenie prístupu k súborom.</string>
     <string name="onboarding_server_pairdrop_summary">(odporúčané)\nPárovacia funkcia, prenos cez internet a zameranie na stabilitu.</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">konec</string>
     <string name="onboarding_choose_server">Izberite naslov strežnika</string>
     <string name="onboarding_choose_server_short">izberite strežnik</string>
-    <string name="onboarding_choose_server_description">Ta aplikacija je optimiziran odjemalec za spletni aplikaciji Snapdrop in PairDrop.\nIzberite enega od naslednjih primerov ali pa vnesite lasten URL za povezavo.\n\nOpomba: v vseh napravah morate izbrati isti URL.</string>
+    <string name="onboarding_choose_server_description">Ta aplikacija je optimiziran odjemalec za spletni aplikaciji ErikrafT Drop in PairDrop.\nIzberite enega od naslednjih primerov ali pa vnesite lasten URL za povezavo.\n\nOpomba: v vseh napravah morate izbrati isti URL.</string>
     <string name="onboarding_storage_permission">Dovoljenje za shrambo</string>
     <string name="onboarding_storage_permission_description">Ta aplikacija je orodje za deljenje datotek. Zato je potrebno dovoljenje za shranjevanje, da jo lahko uporabljate.</string>
     <string name="onboarding_server_pairdrop_summary">(priporočeno)\nZnačilnosti povezovanja, prenosa prek interneta in poudarek na stabilnosti.</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">bitir</string>
     <string name="onboarding_choose_server">Server adresi seçin</string>
     <string name="onboarding_choose_server_short">sunucu seçin</string>
-    <string name="onboarding_choose_server_description">Bu uygulama Snapdrop ve PairDrop web uygulamaları için optimize edilmiş bir istemcidir.\nAşağıdaki örneklerden birini seçin veya bağlanılacak özel bir URL belirtin.\n\nNot: Tüm cihazlarda aynı URL\'yi seçmelisiniz.</string>
+    <string name="onboarding_choose_server_description">Bu uygulama ErikrafT Drop ve PairDrop web uygulamaları için optimize edilmiş bir istemcidir.\nAşağıdaki örneklerden birini seçin veya bağlanılacak özel bir URL belirtin.\n\nNot: Tüm cihazlarda aynı URL\'yi seçmelisiniz.</string>
     <string name="onboarding_storage_permission">Depolama izni</string>
     <string name="onboarding_storage_permission_description">Bu uygulama bir dosya aktarım aracıdır. Uygulamayı kullanabilmek için depolama izni gerekir.</string>
     <string name="onboarding_server_pairdrop_summary">(önerilir)\nEşleştirme özelliği, internet aktarımı ve stabilite üzerine odaklı.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">завершити</string>
     <string name="onboarding_choose_server">Виберіть адресу сервера</string>
     <string name="onboarding_choose_server_short">вибрати сервер</string>
-    <string name="onboarding_choose_server_description">Цей застосунок є оптимізованим клієнтом для вебзастосунків Snapdrop і PairDrop.\nВиберіть один із наведених нижче екземплярів або вкажіть спеціальну URL-адресу для підключення.\n\nПримітка: Вам потрібно вибрати однакову URL-адресу на всіх пристроях.</string>
+    <string name="onboarding_choose_server_description">Цей застосунок є оптимізованим клієнтом для вебзастосунків ErikrafT Drop і PairDrop.\nВиберіть один із наведених нижче екземплярів або вкажіть спеціальну URL-адресу для підключення.\n\nПримітка: Вам потрібно вибрати однакову URL-адресу на всіх пристроях.</string>
     <string name="onboarding_storage_permission">Дозвіл на зберігання</string>
     <string name="onboarding_storage_permission_description">Цей застосунок є засобом для обміну файлами. Тому для його використання потрібен дозвіл на зберігання.</string>
     <string name="onboarding_server_pairdrop_summary">(рекомендовано)\nФункція створення пари, передавання через інтернет та зосередженість на стабільності.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">完成</string>
     <string name="onboarding_choose_server">选择一个服务器地址</string>
     <string name="onboarding_choose_server_short">选择服务器</string>
-    <string name="onboarding_choose_server_description">这个应用程序是适用于 Snapdrop 和 PairDrop 的 Web 应用程序的优化客户端。\n选择以下实例之一或指定要连接的自定义URL。\n\n注意：您必须在所有设备上选择相同的 URL。</string>
+    <string name="onboarding_choose_server_description">这个应用程序是适用于 ErikrafT Drop 和 PairDrop 的 Web 应用程序的优化客户端。\n选择以下实例之一或指定要连接的自定义URL。\n\n注意：您必须在所有设备上选择相同的 URL。</string>
     <string name="onboarding_storage_permission">存储权限</string>
     <string name="onboarding_storage_permission_description">此应用是一个共享文件的工具。因此，需要存储权限才能使用。</string>
     <string name="onboarding_server_pairdrop_summary">(推荐)\n配对功能、互联网传输并侧重于稳定性。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -10,7 +10,7 @@
     <string name="onboarding_button_finish">完成</string>
     <string name="onboarding_choose_server">選擇一個伺服器位址</string>
     <string name="onboarding_choose_server_short">選擇伺服器</string>
-    <string name="onboarding_choose_server_description">這個應用程式是專為 Web 應用程式 Snapdrop 和 PairDrop 最佳化的用戶端。\n選擇以下執行個體或指定一個自訂 URL 以進行連線。\n\n注意：您必須在所有裝置上選擇相同的 URL。</string>
+    <string name="onboarding_choose_server_description">這個應用程式是專為 Web 應用程式 ErikrafT Drop 和 PairDrop 最佳化的用戶端。\n選擇以下執行個體或指定一個自訂 URL 以進行連線。\n\n注意：您必須在所有裝置上選擇相同的 URL。</string>
     <string name="onboarding_storage_permission">儲存空間權限</string>
     <string name="onboarding_storage_permission_description">這是一個用於檔案分享的公用程式，因此，若要使用它，需要授予儲存空間權限。</string>
     <string name="onboarding_server_pairdrop_summary">(建議)\n配對功能，網際網路傳輸並專注於穩定性。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="onboarding_button_finish">finish</string>
     <string name="onboarding_choose_server">Choose a server address</string>
     <string name="onboarding_choose_server_short">choose server</string>
-    <string name="onboarding_choose_server_description">This app is an optimized client for local file sharing.\n\nNote: You have to choose the same URL on all devices.</string>
+    <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
     <string name="onboarding_server_pairdrop_summary">(recommended)\nPairing feature, internet transfer and focus on stability.</string>


### PR DESCRIPTION
## Summary
- update the onboarding instructions to describe the ErikrafT Drop and PairDrop web apps
- refresh the localized onboarding descriptions so they reference ErikrafT Drop across supported languages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e44e8cd5dc832aa25628790c6c5bfb