### PR TITLE
Refresh about page credits and default server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ However, even if it theoretically would fully work in your browser and you don't
 <img src="app/src/main/res/drawable/tv_banner.png" width="43.3%"></img> <img src=".screenshot/ErikrafTdrop_screenshot_mobile_1.png" width="10%"></img> <img src=".screenshot/ErikrafTdrop_screenshot_mobile_10.png" width="10%"></img> <img src=".screenshot/ErikrafTdrop_screenshot_mobile_2.png" width="10%"></img>
 
 ## Support ErikrafT Drop
-➡️ [See how you can support this app and the ErikrafT Drop community](https://github.com/erikraft/Drop-Android/blob/master/FUNDING.md)
+➡️ [See how you can support this app and the ErikrafT Drop community](https://ko-fi.com/erikraft/)
 
 ## Contributing
 **ErikrafT Drop for Android** would like to become a community project. I invite your participation through issues and pull requests! Also bug reports are very welcome! But note that this is **not** the right place to report bugs regarding the **ErikrafT Drop website** which occur independently of this app.

--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -28,7 +28,7 @@ try {
 
 //change tweet link
 try {
-    document.querySelector('.icon-button[title~="Tweet"]').href = 'https://twitter.com/intent/tweet?text=@ErikrafTdrop%20-%20%22ErikrafT%20Drop%22%20is%20an%20Android%20client%20for%20local%20file%20sharing%0A%0A%23erikraftdrop';
+    document.querySelector('.icon-button[title~="Tweet"]').href = 'https://x.com/ErikrafTbr';
 } catch (e) {
     console.error(e);
 }
@@ -57,7 +57,7 @@ try {
 
 //retarget donation button (play guidelines)
 try {
-    document.querySelector('.icon-button[href*="paypal"]').href = 'https://github.com/fm-sys/snapdrop-android/blob/master/FUNDING.md';
+    document.querySelector('.icon-button[href*="paypal"]').href = 'https://ko-fi.com/erikraft/';
 } catch (e) {
     console.error(e);
 }

--- a/app/src/main/java/com/erikraft/drop/MainActivity.java
+++ b/app/src/main/java/com/erikraft/drop/MainActivity.java
@@ -192,7 +192,7 @@ public class MainActivity extends AppCompatActivity {
             return; // all this doesn't make sense if we have no base URL
         }
 
-        if (baseURL.equals("https://snapdrop.net")) {
+        if (baseURL.startsWith("https://snapdrop.net")) {
             openSettingsResultLauncher.launch(OnboardingActivity.getServerSelectionIntent(this));
         }
 
@@ -307,7 +307,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private boolean isPairDrop() {
-        return baseURL.equals(getString(R.string.onboarding_server_pairdrop));
+        return baseURL != null && (baseURL.startsWith(getString(R.string.onboarding_server_pairdrop))
+                || baseURL.startsWith("https://drop.erikraft.com"));
     }
 
     @Override

--- a/app/src/main/java/com/erikraft/drop/SettingsFragment.java
+++ b/app/src/main/java/com/erikraft/drop/SettingsFragment.java
@@ -90,7 +90,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             storageHelper.onRestoreInstanceState(savedInstanceState);
         }
 
-        initUrlPreference(R.string.pref_support, "https://github.com/fm-sys/snapdrop-android/blob/master/FUNDING.md");
+        initUrlPreference(R.string.pref_support, "https://ko-fi.com/erikraft/");
 
         final Preference openSourceComponents = findPreference(getString(R.string.pref_about));
         openSourceComponents.setOnPreferenceClickListener(pref -> {
@@ -99,14 +99,17 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     .withAboutIconShown(true)
                     .withAboutVersionShownName(true)
                     .withAboutDescription("<big><b>Credits</b></big><br><br>" +
-                            "This app and its launcher icon is based on the snapdrop.net project by RobinLinus<br>" +
-                            "<a href=\"https://github.com/RobinLinus/snapdrop\">github.com/RobinLinus/snapdrop</a><br><br>" +
+                            "This app and its launcher icon are based on the PairDrop project by schlagmichdoch<br>" +
+                            "<a href=\"https://github.com/schlagmichdoch/PairDrop/\">github.com/schlagmichdoch/PairDrop</a><br><br>" +
+                            "It uses the official ErikrafT Drop codebase as its foundation<br>" +
+                            "<a href=\"https://github.com/erikraft/Drop\">github.com/erikraft/Drop</a><br>" +
+                            "with the Android client maintained at<br>" +
+                            "<a href=\"https://github.com/erikraft/Drop-Android\">github.com/erikraft/Drop-Android</a><br><br>" +
                             "<big><b>" + getString(R.string.support_us) + "</b></big><br><br>" +
                             getString(R.string.support_us_summary) + "<br>" +
-                            "<a href=\"https://github.com/fm-sys/snapdrop-android/blob/master/FUNDING.md\">" + getString(R.string.read_more) + "</a>")
+                            "<a href=\"https://ko-fi.com/erikraft/\">" + getString(R.string.read_more) + "</a>")
                     .withAboutSpecial1("GitHub")
-                    .withAboutSpecial2("Twitter/X")
-                    .withAboutSpecial3("Crowdin")
+                    .withAboutSpecial2("𝕏｜Twitter")
                     .withListener(new AboutLibrariesListener() {
                         @Override
                         public boolean onIconLongClicked(final @NonNull View view) {
@@ -134,17 +137,15 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
                         @Override
                         public void onIconClicked(final @NonNull View view) {
-                            ShareUtils.openUrl(SettingsFragment.this, "https://github.com/fm-sys/snapdrop-android");
+                            ShareUtils.openUrl(SettingsFragment.this, "https://github.com/erikraft/Drop-Android");
                         }
 
                         @Override
                         public boolean onExtraClicked(final @NonNull View view, final @NonNull SpecialButton specialButton) {
                             if (specialButton == SpecialButton.SPECIAL1) {
-                                ShareUtils.openUrl(SettingsFragment.this, "https://github.com/fm-sys/snapdrop-android");
+                                ShareUtils.openUrl(SettingsFragment.this, "https://github.com/erikraft/Drop-Android");
                             } else if (specialButton == SpecialButton.SPECIAL2) {
-                                ShareUtils.openUrl(SettingsFragment.this, "https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20%22Snapdrop%20%26%20PairDrop%20for%20Android%22%20is%20an%20Android%20client%20for%20https://snapdrop.net%20and%20https://pairdrop.net%0A%0A%23snapdrop");
-                            } else if (specialButton == SpecialButton.SPECIAL3) {
-                                ShareUtils.openUrl(SettingsFragment.this, "https://crowdin.com/project/snapdrop-android");
+                                ShareUtils.openUrl(SettingsFragment.this, "https://x.com/ErikrafTbr");
                             }
                             return true;
                         }

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">اكتمل</string>
     <string name="onboarding_choose_server">اختر عنوان الخادم</string>
     <string name="onboarding_choose_server_short">اختر الخادم</string>
-    <string name="onboarding_choose_server_description">هذا التطبيق هو عميل مُحسَّن لتطبيقات الويب Snaplop و PairDrop.\nاختر واحدة من الأمثلة التالية أو حدد عنوان URL مخصص للاتصال به.\n\nملاحظة: يجب عليك اختيار نفس الرابط على جميع الأجهزة.</string>
+    <string name="onboarding_choose_server_description">هذا التطبيق هو عميل مُحسَّن لتطبيقات الويب ErikrafT Drop و PairDrop.\nاختر واحدة من الأمثلة التالية أو حدد عنوان URL مخصص للاتصال به.\n\nملاحظة: يجب عليك اختيار نفس الرابط على جميع الأجهزة.</string>
     <string name="onboarding_storage_permission">إذن التخزين</string>
     <string name="onboarding_storage_permission_description">هذا التطبيق هو أداة مشاركة للملفات. لذلك، إذن التخزين مطلوب لاستخدامه.</string>
     <string name="onboarding_server_pairdrop_summary">(موصى به)\nميزة الاقتران ، نقل الإنترنت والتركيز على الاستقرار.</string>
@@ -52,10 +52,10 @@
     <string name="keep_on_summary">(مستحسن) العديد من الأجهزة تواجه مشاكل مع انقطاع عمليات النقل عند ايقاف تشغيل الشاشة</string>
     <string name="keep_on_title">إبقاء الشاشة قيد التشغيل أثناء النقل</string>
     <string name="floating_text_selection_title">اختيار النص العائم</string>
-    <string name="floating_text_selection_summary">عند تحديد النص في تطبيقات أخرى، سيتم عرض خيار \"إرسال مع Snapdrop\"</string>
+    <string name="floating_text_selection_summary">عند تحديد النص في تطبيقات أخرى، سيتم عرض خيار \"إرسال مع ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">تحذير الاتصال</string>
     <string name="show_connectivity_card_summary"> إظهار تحذير عندما لا تكون متصلاً بشبكة Wi-Fi</string>
-    <string name="floating_text_selection_activity_label">مشاركة مع سناب درُوب</string>
+    <string name="floating_text_selection_activity_label">مشاركة مع ErikrafT Drop</string>
     <string name="permission_not_granted">الرجاء منح الأذونات الضرورية</string>
     <string name="permission_not_granted_fallback">الرجاء منح الأذونات الضرورية</string>
     <string name="open_settings">فتح الإعدادات</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -26,8 +26,8 @@
     <string name="keep_on_summary">(Препоръчително) Много устройства имат проблем с прекъсване при прехвърляне на файлове щом екрана се изключи</string>
     <string name="keep_on_title">Дръж екрана включен докато се прехвърлят файлове</string>
     <string name="floating_text_selection_title">Избор на плаващ текст</string>
-    <string name="floating_text_selection_summary">Когато избираш текст в друго приложение, ще се покаже опция \"Изпрати чрез Snapdrop\"</string>
-    <string name="floating_text_selection_activity_label">Изпрати чрез Snapdrop</string>
+    <string name="floating_text_selection_summary">Когато избираш текст в друго приложение, ще се покаже опция \"Изпрати чрез ErikrafT Drop\"</string>
+    <string name="floating_text_selection_activity_label">Изпрати чрез ErikrafT Drop</string>
     <string name="settings_theme_title">Тема</string>
     <string-array name="darkmode_entries">
         <item>По подразбиране</item>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">finalitza</string>
     <string name="onboarding_choose_server">Trieu una adreça del servidor</string>
     <string name="onboarding_choose_server_short">trieu el servidor</string>
-    <string name="onboarding_choose_server_description">Aquesta aplicació és un client optimitzat per a les aplicacions web Snapdrop i PairDrop.\nTrieu una de les següents instàncies o especifiqueu un URL personalitzat per connectar-vos.\n\nNota: Heu de triar el mateix URL en tots els dispositius.</string>
+    <string name="onboarding_choose_server_description">Aquesta aplicació és un client optimitzat per a les aplicacions web ErikrafT Drop i PairDrop.\nTrieu una de les següents instàncies o especifiqueu un URL personalitzat per connectar-vos.\n\nNota: Heu de triar el mateix URL en tots els dispositius.</string>
     <string name="onboarding_storage_permission">Permís d\'emmagatzematge</string>
     <string name="onboarding_storage_permission_description">Aquesta aplicació és una utilitat per compartir fitxers. Per tant, es requereix el permís d\'emmagatzematge per poder utilitzar-la.</string>
     <string name="onboarding_server_pairdrop_summary">(recomanat)\nFunció d\'emparellament, transferència per Internet i enfocat en l\'estabilitat.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Recomanat) Molts dispositius tenen problemes amb transferiments detinguts degut a que la pantalla s\'apagui</string>
     <string name="keep_on_title">Deixa la pantalla encesa mentre es transfereix</string>
     <string name="floating_text_selection_title">Selecció del text flotant</string>
-    <string name="floating_text_selection_summary">Quan se seleccioni text en altres aplicacions, l\'opció \"Enviar amb snapdrop\" sortirà</string>
+    <string name="floating_text_selection_summary">Quan se seleccioni text en altres aplicacions, l\'opció \"Enviar amb ErikrafT Drop\" sortirà</string>
     <string name="show_connectivity_card_title">Avís de connectivitat</string>
     <string name="show_connectivity_card_summary"> Mostra un avís quan no estigueu connectat amb wifi</string>
-    <string name="floating_text_selection_activity_label">Envia amb Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Envia amb ErikrafT Drop</string>
     <string name="permission_not_granted">concediu el permís necessari</string>
     <string name="permission_not_granted_fallback">concediu manualment el permís necessari</string>
     <string name="open_settings">obre la configuració</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">dokončit</string>
     <string name="onboarding_choose_server">Vyberte adresu serveru</string>
     <string name="onboarding_choose_server_short">vybrat server</string>
-    <string name="onboarding_choose_server_description">Tato aplikace je optimalizovaným klientem pro webové aplikace Snapdrop a PairDrop.\nVyberte jednu z následujících instancí nebo zadejte vlastní adresu URL pro připojení.\n\nPoznámka: Musíte vybrat stejnou adresu URL na všech zařízeních.</string>
+    <string name="onboarding_choose_server_description">Tato aplikace je optimalizovaným klientem pro webové aplikace ErikrafT Drop a PairDrop.\nVyberte jednu z následujících instancí nebo zadejte vlastní adresu URL pro připojení.\n\nPoznámka: Musíte vybrat stejnou adresu URL na všech zařízeních.</string>
     <string name="onboarding_storage_permission">Oprávnění úložiště</string>
     <string name="onboarding_storage_permission_description">Tato aplikace je nástroj pro sdílení souborů. Proto je vyžadováno oprávnění pro její používání.</string>
     <string name="onboarding_server_pairdrop_summary">(doporučeno)\nPárování, internetový přenos a zaměření na stabilitu.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Doporučeno) Mnoho zařízení má problémy s přerušením přenosu při vypnutí obrazovky</string>
     <string name="keep_on_title">Během přenosu udržujte obrazovku zapnutou</string>
     <string name="floating_text_selection_title">Výběr plovoucího textu</string>
-    <string name="floating_text_selection_summary">Při výběru textu v jiných aplikacích bude zobrazena možnost \"Odeslat aplikací Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Při výběru textu v jiných aplikacích bude zobrazena možnost \"Odeslat aplikací ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Upozornění na připojení</string>
     <string name="show_connectivity_card_summary"> Zobrazit varování, pokud nejste připojeni k síti WiFi</string>
-    <string name="floating_text_selection_activity_label">Odeslat aplikací Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Odeslat aplikací ErikrafT Drop</string>
     <string name="permission_not_granted">udělte prosím potřebná oprávnění</string>
     <string name="permission_not_granted_fallback">udělte prosím potřebná oprávnění manuálně</string>
     <string name="open_settings">otevřít nastavení</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">fertigstellen</string>
     <string name="onboarding_choose_server">Serveradresse wählen</string>
     <string name="onboarding_choose_server_short">Server wählen</string>
-    <string name="onboarding_choose_server_description">Diese App ist ein optimierter Client für die Webanwendungen Snapdrop und PairDrop.\nWählen Sie eine der folgenden Instanzen oder geben Sie eine benutzerdefinierte URL an, mit der Sie sich verbinden möchten.\n\nHinweis: Sie müssen auf allen Geräten die gleiche URL wählen.</string>
+    <string name="onboarding_choose_server_description">Diese App ist ein optimierter Client für die Webanwendungen ErikrafT Drop und PairDrop.\nWählen Sie eine der folgenden Instanzen oder geben Sie eine benutzerdefinierte URL an, mit der Sie sich verbinden möchten.\n\nHinweis: Sie müssen auf allen Geräten die gleiche URL wählen.</string>
     <string name="onboarding_storage_permission">Speicherberechtigung</string>
     <string name="onboarding_storage_permission_description">Diese App ist ein Datei-Freigabe-Programm. Daher ist die Speicher-Berechtigung erforderlich, um funktionieren zu können.</string>
     <string name="onboarding_server_pairdrop_summary">(empfohlen)\nKopplungsfunktion, Internet-Übertragung und Fokus auf Stabilität.</string>
@@ -52,10 +52,10 @@
     <string name="keep_on_summary">(Empfohlen) Viele Geräte haben Probleme mit Übertragungen, wenn der Bildschirm ausgeschaltet wird</string>
     <string name="keep_on_title">Bildschirm während der Übertragung angeschaltet lassen</string>
     <string name="floating_text_selection_title">Schwebende Textauswahl</string>
-    <string name="floating_text_selection_summary">Bei der Auswahl von Text in anderen Apps wird die Option \"Mit Snapdrop senden\" angezeigt</string>
+    <string name="floating_text_selection_summary">Bei der Auswahl von Text in anderen Apps wird die Option \"Mit ErikrafT Drop senden\" angezeigt</string>
     <string name="show_connectivity_card_title">Verbindungswarnung</string>
     <string name="show_connectivity_card_summary"> Warnung anzeigen, wenn nicht mit einem WLAN-Netzwerk verbunden</string>
-    <string name="floating_text_selection_activity_label">Mit Snapdrop senden</string>
+    <string name="floating_text_selection_activity_label">Mit ErikrafT Drop senden</string>
     <string name="permission_not_granted">Bitte erteilen Sie die notwendige Berechtigung</string>
     <string name="permission_not_granted_fallback">Bitte erteilen Sie die notwendige Berechtigung manuell</string>
     <string name="open_settings">Einstellungen öffnen</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">ολοκλήρωση</string>
     <string name="onboarding_choose_server">Επιλέξτε διεύθυνση διακομιστή</string>
     <string name="onboarding_choose_server_short">επιλέξτε διακομιστή</string>
-    <string name="onboarding_choose_server_description">Αυτή η εφαρμογή είναι ένας βελτιστοποιημένος client για τις web εφαρμογές Snapdrop και PairDrop.\nΕπιλέξτε μία από τις ακόλουθες επιλογές ή καθορίστε μια προσαρμοσμένη διεύθυνση URL για να συνδεθίιτε.\n\nΣημείωση: Πρέπει να επιλέξετε το ίδιο URL σε όλες τις συσκευές.</string>
+    <string name="onboarding_choose_server_description">Αυτή η εφαρμογή είναι ένας βελτιστοποιημένος client για τις web εφαρμογές ErikrafT Drop και PairDrop.\nΕπιλέξτε μία από τις ακόλουθες επιλογές ή καθορίστε μια προσαρμοσμένη διεύθυνση URL για να συνδεθίιτε.\n\nΣημείωση: Πρέπει να επιλέξετε το ίδιο URL σε όλες τις συσκευές.</string>
     <string name="onboarding_storage_permission">Άδεια αποθήκευσης</string>
     <string name="onboarding_storage_permission_description">Αυτή η εφαρμογή είναι ένα πρόγραμμα κοινής χρήσης αρχείων. Ως εκ τούτου, απαιτείται άδεια αποθήκευσης για να μπορεί να χρησιμοποιηθεί.</string>
     <string name="onboarding_server_pairdrop_summary">(συνιστάται)\nΛειτουργία σύζευξης, μεταφορά μέσω διαδικτύου με στόχο τη σταθερότητα.</string>
@@ -52,10 +52,10 @@
     <string name="keep_on_summary">(Προτείνεται) Πολλές συσκευές αντιμετωπίζουν προβλήματα με μεταφορές αρχείων οπού διακόπτονται διότι η οθόνη απενεργοποιείται</string>
     <string name="keep_on_title">Διατηρήστε την οθόνη ενεργή κατά τη μεταφορά</string>
     <string name="floating_text_selection_title">Επιλογή Floating text</string>
-    <string name="floating_text_selection_summary">Κατά την επιλογή κειμένου σε άλλες εφαρμογές, θα εμφανιστεί η επιλογή \"Αποστολή με Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Κατά την επιλογή κειμένου σε άλλες εφαρμογές, θα εμφανιστεί η επιλογή \"Αποστολή με ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Προειδοποίηση συνδεσιμότητας</string>
     <string name="show_connectivity_card_summary"> Εμφάνιση προειδοποίησης όταν δεν είστε συνδεδεμένοι με δίκτυο WiFi</string>
-    <string name="floating_text_selection_activity_label">Αποστολή με Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Αποστολή με ErikrafT Drop</string>
     <string name="permission_not_granted">παρακαλώ, παραχωρήστε την απαιτούμενη άδεια</string>
     <string name="permission_not_granted_fallback">παρακαλώ, παραχωρήστε την απαιτούμενη άδεια χειροκίνητα</string>
     <string name="open_settings">άνοιγμα ρυθμίσεων</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminar</string>
     <string name="onboarding_choose_server">Elige un servidor</string>
     <string name="onboarding_choose_server_short">elegir servidor</string>
-    <string name="onboarding_choose_server_description">Esta aplicación es un cliente optimizado para las aplicaciones web Snapdrop y PairDrop.\nElige una de las siguientes instancias o especifica una url personalizada a la que conectarse.\n\nNota: Tienes que elegir la misma URL en todos los dispositivos.</string>
+    <string name="onboarding_choose_server_description">Esta aplicación es un cliente optimizado para las aplicaciones web ErikrafT Drop y PairDrop.\nElige una de las siguientes instancias o especifica una url personalizada a la que conectarse.\n\nNota: Tienes que elegir la misma URL en todos los dispositivos.</string>
     <string name="onboarding_storage_permission">Permiso de almacenamiento</string>
     <string name="onboarding_storage_permission_description">Esta aplicación es una utilidad para compartir archivos. Por lo tanto, el permiso de almacenamiento es necesario para usarla.</string>
     <string name="onboarding_server_pairdrop_summary">(recomendado)\nFunción de emparejamiento, transferencia por Internet y enfoque en estabilidad.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Recomendado) Muchos dispositivos tienen problemas con las interrupciones de transferencias cuando la pantalla se apaga</string>
     <string name="keep_on_title">Mantener la pantalla encendida mientras se transfiere</string>
     <string name="floating_text_selection_title">Selección de texto flotante</string>
-    <string name="floating_text_selection_summary">Al seleccionar texto en otras aplicaciones, se mostrará una opción \"Enviar con Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Al seleccionar texto en otras aplicaciones, se mostrará una opción \"Enviar con ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Advertencia de conexión</string>
     <string name="show_connectivity_card_summary"> Mostrar una advertencia cuando no esté conectado a una red WiFi</string>
-    <string name="floating_text_selection_activity_label">Enviar con Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Enviar con ErikrafT Drop</string>
     <string name="permission_not_granted">por favor conceda el permiso necesario</string>
     <string name="permission_not_granted_fallback">por favor conceda el permiso necesario manualmente</string>
     <string name="open_settings">abrir ajustes</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminer</string>
     <string name="onboarding_choose_server">Choisir une adresse de serveur</string>
     <string name="onboarding_choose_server_short">Choisir le serveur</string>
-    <string name="onboarding_choose_server_description">Cette application est un client optimisé pour les applications web Snapdrop et PairDrop.\nChoisissez l\'une des instances suivantes ou spécifiez un URL personnalisé à laquelle vous devez vous connecter.\n\nNote : Vous devez choisir le même URL sur tous les appareils.</string>
+    <string name="onboarding_choose_server_description">Cette application est un client optimisé pour les applications web ErikrafT Drop et PairDrop.\nChoisissez l\'une des instances suivantes ou spécifiez un URL personnalisé à laquelle vous devez vous connecter.\n\nNote : Vous devez choisir le même URL sur tous les appareils.</string>
     <string name="onboarding_storage_permission">Autorisation d\'accès au stockage</string>
     <string name="onboarding_storage_permission_description">Cette application est un utilitaire de partage de fichiers. Par conséquent, une autorisation de stockage est nécessaire pour l\'utiliser.</string>
     <string name="onboarding_server_pairdrop_summary">(recommandé)\nFonctionnalité d\'appairage, transfert par internet et priorité à la stabilité.</string>
@@ -50,10 +50,10 @@
     <string name="keep_on_summary">(Recommandé) De nombreux appareils ont des problèmes d\"interruption de transfert lorsque l\'écran s\'éteint</string>
     <string name="keep_on_title">Garder l\'écran allumé pendant le transfert</string>
     <string name="floating_text_selection_title">Sélection de texte flottante</string>
-    <string name="floating_text_selection_summary">Lors de la sélection de texte dans d\'autres applications, une option \"Envoyer via Snapdrop\" sera affichée</string>
+    <string name="floating_text_selection_summary">Lors de la sélection de texte dans d\'autres applications, une option \"Envoyer via ErikrafT Drop\" sera affichée</string>
     <string name="show_connectivity_card_title">Avertissement sur la connexion</string>
     <string name="show_connectivity_card_summary"> Afficher un avertissement lorsque vous n\'êtes pas connecté à un réseau Wi-Fi</string>
-    <string name="floating_text_selection_activity_label">Envoyer via Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Envoyer via ErikrafT Drop</string>
     <string name="permission_not_granted">veuillez accorder l\'autorisation nécessaire</string>
     <string name="permission_not_granted_fallback">veuillez accorder manuellement l\'autorisation nécessaire</string>
     <string name="open_settings">ouvrir les paramètres</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -20,8 +20,8 @@
     <string name="keep_on_summary">(अनुशंसित) स्क्रीन बंद होने पर कई उपकरणों में स्थानांतरण बाधित होने की समस्या होती है</string>
     <string name="keep_on_title">ट्रांसफर करते समय स्क्रीन ऑन रखें।</string>
     <string name="floating_text_selection_title">फ्लोटिंग टेक्स्ट सिलेक्शन</string>
-    <string name="floating_text_selection_summary">अन्य ऐप्स में टेक्स्ट को सिलेक्ट करते समय, \"स्नैपड्रॉप के साथ भेजें\" विकल्प दिखाया जाएगा।</string>
-    <string name="floating_text_selection_activity_label">स्नैपड्रॉप के साथ भेजें</string>
+    <string name="floating_text_selection_summary">अन्य ऐप्स में टेक्स्ट को सिलेक्ट करते समय, \"ErikrafT Drop के साथ भेजें\" विकल्प दिखाया जाएगा।</string>
+    <string name="floating_text_selection_activity_label">ErikrafT Drop के साथ भेजें</string>
     <string name="settings_theme_title">थीम</string>
     <string-array name="darkmode_entries">
         <item>सिस्टम डिफ़ॉल्ट का इस्तेमाल करें</item>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -22,8 +22,8 @@
     <string name="keep_on_summary">(Ajánlott) Sok eszköznél megszakad az átvitel, ha a kijelző kikapcsol</string>
     <string name="keep_on_title">A képernyő bekapcsolva tartása átvitel közben</string>
     <string name="floating_text_selection_title">Lebegő szöveg kijelölése</string>
-    <string name="floating_text_selection_summary">Ha más alkalmazásokban szöveget jelöl ki, megjelenik a „Küldés snapdroppal” lehetőség</string>
-    <string name="floating_text_selection_activity_label">Küldés snapdroppal</string>
+    <string name="floating_text_selection_summary">Ha más alkalmazásokban szöveget jelöl ki, megjelenik a „Küldés ErikrafT Drop-pal” lehetőség</string>
+    <string name="floating_text_selection_activity_label">Küldés ErikrafT Drop-pal</string>
     <string name="settings_theme_title">Téma</string>
     <string-array name="darkmode_entries">
         <item>A rendszer beállításainak használata</item>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">selesai</string>
     <string name="onboarding_choose_server">Pilih alamat server</string>
     <string name="onboarding_choose_server_short">pilih server</string>
-    <string name="onboarding_choose_server_description">Aplikasi ini adalah klien yang dioptimalkan untuk aplikasi web Snapdrop dan PairDrop.\nPilih salah satu dari beberapa opsi berikut atau tentukan url khusus agar dapat tersambung.\n\nCatatan: Anda harus menggunakan URL yang sama di semua perangkat.</string>
+    <string name="onboarding_choose_server_description">Aplikasi ini adalah klien yang dioptimalkan untuk aplikasi web ErikrafT Drop dan PairDrop.\nPilih salah satu dari beberapa opsi berikut atau tentukan url khusus agar dapat tersambung.\n\nCatatan: Anda harus menggunakan URL yang sama di semua perangkat.</string>
     <string name="onboarding_storage_permission">Izin penyimpanan</string>
     <string name="onboarding_storage_permission_description">Aplikasi ini adalah aplikasi berbagi file. Oleh karena itu, izin penyimpanan diperlukan untuk bisa digunakan.</string>
     <string name="onboarding_server_pairdrop_summary">(disarankan)\nFitur pairing, transfer internet dan fokus pada kestabilan.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Disarankan) Kebanyakan perangkat mengalami masalah transfer terputus ketika layar dalam keadaan mati</string>
     <string name="keep_on_title">Tetap aktifkan layar saat mentransfer</string>
     <string name="floating_text_selection_title">Pilihan teks mengambang</string>
-    <string name="floating_text_selection_summary">Saat memilih teks di aplikasi lain, opsi \"Kirim dengan Snapdrop\" akan ditampilkan</string>
+    <string name="floating_text_selection_summary">Saat memilih teks di aplikasi lain, opsi \"Kirim dengan ErikrafT Drop\" akan ditampilkan</string>
     <string name="show_connectivity_card_title">Peringatan konektivitas</string>
     <string name="show_connectivity_card_summary"> Menampilkan peringatan saat Anda tidak tersambung dengan jaringan WiFi</string>
-    <string name="floating_text_selection_activity_label">Kirim dengan Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Kirim dengan ErikrafT Drop</string>
     <string name="permission_not_granted">mohon berikan izin yang diperlukan</string>
     <string name="permission_not_granted_fallback">mohon berikan izin yang diperlukan secara manual</string>
     <string name="open_settings">buka setelan</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -9,7 +9,7 @@
     <string name="onboarding_button_grant">concedi l\'autorizzazione</string>
     <string name="onboarding_button_finish">fine</string>
     <string name="onboarding_choose_server">Scegli un indirizzo del server</string>
-    <string name="onboarding_choose_server_description">Questa app è un client ottimizzato per le applicazioni web Snapdrop e PairDrop.\nScegli una delle seguenti istanze o specifica un URL personalizzato a cui connettersi.\n\nNota: Devi scegliere lo stesso URL su tutti i dispositivi.</string>
+    <string name="onboarding_choose_server_description">Questa app è un client ottimizzato per le applicazioni web ErikrafT Drop e PairDrop.\nScegli una delle seguenti istanze o specifica un URL personalizzato a cui connettersi.\n\nNota: Devi scegliere lo stesso URL su tutti i dispositivi.</string>
     <string name="onboarding_storage_permission">Autorizzazione di archiviazione</string>
     <string name="onboarding_storage_permission_description">Questa app è un\'utilità di condivisione di file. Pertanto, è richiesta l\'autorizzazione di archiviazione per utilizzarla.</string>
     <string name="onboarding_server_pairdrop_summary">(raccomandato)\nFunzionalità di collegamento, trasferimento internet e si concentra sulla stabilità.</string>
@@ -40,8 +40,8 @@
     <string name="keep_on_summary">(Consigliato) Molti dispositivi interrompono il trasferimento quando lo schermo si spegne</string>
     <string name="keep_on_title">Mantieni lo schermo attivo durante il trasferimento</string>
     <string name="floating_text_selection_title">Selezione testo fluttuante</string>
-    <string name="floating_text_selection_summary">Se selezioni il testo in altre app, comparirà un\'opzione \"invia con Snapdrop\"</string>
-    <string name="floating_text_selection_activity_label">Invia con Snapdrop</string>
+    <string name="floating_text_selection_summary">Se selezioni il testo in altre app, comparirà un\'opzione \"invia con ErikrafT Drop\"</string>
+    <string name="floating_text_selection_activity_label">Invia con ErikrafT Drop</string>
     <string name="settings_theme_title">Tema</string>
     <string-array name="darkmode_entries">
         <item>Predefinito</item>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -22,8 +22,8 @@
     <string name="keep_on_summary">(מומלץ) להמון מכשירים יש בעיות שהעברת הקבצים נקטעת כשמכבים את מסך המכשיר</string>
     <string name="keep_on_title">השאר מסך דולק במשך העברת הקבצים</string>
     <string name="floating_text_selection_title">בחירת טקסט צף</string>
-    <string name="floating_text_selection_summary">כשתבחר שורת טקסט ביישום אחר, יפתח אפשרות של \"שתף עם סנאפדרופ\"</string>
-    <string name="floating_text_selection_activity_label">שתף עם סנאפדרופ</string>
+    <string name="floating_text_selection_summary">כשתבחר שורת טקסט ביישום אחר, יפתח אפשרות של \"שתף עם ErikrafT Drop\"</string>
+    <string name="floating_text_selection_activity_label">שתף עם ErikrafT Drop</string>
     <string name="settings_theme_title">ערכת נושא</string>
     <string-array name="darkmode_entries">
         <item>ברירת מחדל של המערכת</item>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -10,7 +10,7 @@
     <string name="onboarding_button_finish">完了</string>
     <string name="onboarding_choose_server">サーバー選択</string>
     <string name="onboarding_choose_server_short">サーバー選択</string>
-    <string name="onboarding_choose_server_description">このアプリはウェブアプリのSnapdropとPairDropに対応しています。\n以下のサーバーを選択するか、カスタムサーバーのURLを入力してください。\n\n注意: すべてのデバイスで同じサーバーに接続する必要があります。</string>
+    <string name="onboarding_choose_server_description">このアプリはウェブアプリのErikrafT DropとPairDropに対応しています。\n以下のサーバーを選択するか、カスタムサーバーのURLを入力してください。\n\n注意: すべてのデバイスで同じサーバーに接続する必要があります。</string>
     <string name="onboarding_storage_permission">ストレージ権限</string>
     <string name="onboarding_storage_permission_description">このアプリはファイル共有ツールです。そのため、ストレージへのアクセス許可が必要です。</string>
     <string name="onboarding_server_pairdrop_summary">(推奨)\nペアリングやインターネット上での転送機能があり、安定しています。</string>
@@ -48,10 +48,10 @@
     <string name="keep_on_summary">(推奨) 多くのデバイスで画面の消灯時に転送が中止される問題が発生します</string>
     <string name="keep_on_title">転送時に画面を点灯したままにする</string>
     <string name="floating_text_selection_title">テキスト選択メニューに表示</string>
-    <string name="floating_text_selection_summary">他のアプリでテキストを選択すると､「Snapdropで送信」オプションが表示されます</string>
+    <string name="floating_text_selection_summary">他のアプリでテキストを選択すると､「ErikrafT Dropで送信」オプションが表示されます</string>
     <string name="show_connectivity_card_title">接続警告</string>
     <string name="show_connectivity_card_summary"> WiFiに接続していない場合に警告を表示する</string>
-    <string name="floating_text_selection_activity_label">Snapdropで送信</string>
+    <string name="floating_text_selection_activity_label">ErikrafT Dropで送信</string>
     <string name="permission_not_granted">必要な権限を許可してください</string>
     <string name="permission_not_granted_fallback">必要な権限を手動で許可してください</string>
     <string name="open_settings">設定を開く</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">완료</string>
     <string name="onboarding_choose_server">서버 주소를 선택하세요</string>
     <string name="onboarding_choose_server_short">서버 선택</string>
-    <string name="onboarding_choose_server_description">이 애플리케이션은 Snapdrop과 PairDrop 웹 앱에 대응되는 최적화된 클라이언트 입니다.\n다음 중 하나의 인스턴스를 고르거나, 연결할 커스텀 URL을 입력하세요.\n\n메모: 사용할 모든 기기가 같은 URL에 연결되어야 합니다.</string>
+    <string name="onboarding_choose_server_description">이 애플리케이션은 ErikrafT Drop과 PairDrop 웹 앱에 대응되는 최적화된 클라이언트 입니다.\n다음 중 하나의 인스턴스를 고르거나, 연결할 커스텀 URL을 입력하세요.\n\n메모: 사용할 모든 기기가 같은 URL에 연결되어야 합니다.</string>
     <string name="onboarding_storage_permission">저장소 권한</string>
     <string name="onboarding_storage_permission_description">이 앱은 파일 공유 유틸리티입니다. 파일에 접근하기 위해 저장소 접근 권한이 필요합니다.</string>
     <string name="onboarding_server_pairdrop_summary">(추천)\n페어링 기능, 인터넷을 통한 전송 그리고 더 높은 안정성.</string>
@@ -47,10 +47,10 @@
     <string name="keep_on_summary">(권장함) 많은 기기에 화면이 꺼지면 전송이 중단되는 문제가 있습니다.</string>
     <string name="keep_on_title">전송 중일때 화면 켜짐 유지</string>
     <string name="floating_text_selection_title">선택된 텍스트 보내기</string>
-    <string name="floating_text_selection_summary">다른 애플리케이션에서 텍스트를 선택할 때, \"Snapdrop으로 보내기\" 옵션이 표시됩니다.</string>
+    <string name="floating_text_selection_summary">다른 애플리케이션에서 텍스트를 선택할 때, \"ErikrafT Drop으로 보내기\" 옵션이 표시됩니다.</string>
     <string name="show_connectivity_card_title">연결 안정성 경고</string>
     <string name="show_connectivity_card_summary"> WiFi 네트워크에 연결되어 있지 않을 때 경고를 표시합니다</string>
-    <string name="floating_text_selection_activity_label">Snapdrop으로 보내기</string>
+    <string name="floating_text_selection_activity_label">ErikrafT Drop으로 보내기</string>
     <string name="permission_not_granted">권한을 허용해주십시오</string>
     <string name="permission_not_granted_fallback">권한을 수동으로 허용해주십시오</string>
     <string name="open_settings">설정 열기</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -22,8 +22,8 @@
     <string name="keep_on_summary">(सिफारिस गरिएको) धेरै यन्त्रहरूमा स्क्रिन बन्द हुँदा स्थानान्तरणमा अवरोध हुने समस्याहरू छन्</string>
     <string name="keep_on_title">स्थानान्तरण गर्दा स्क्रिन अन राख्नुहोस्</string>
     <string name="floating_text_selection_title">फ्लोटिंग पाठ चयन</string>
-    <string name="floating_text_selection_summary">अन्य एपहरूमा पाठ चयन गर्दा, \"Snapdrop सँग पठाउनुहोस्\" विकल्प देखाइनेछ</string>
-    <string name="floating_text_selection_activity_label">Snapdrop मार्फत पठाउनुहोस्</string>
+    <string name="floating_text_selection_summary">अन्य एपहरूमा पाठ चयन गर्दा, \"ErikrafT Drop सँग पठाउनुहोस्\" विकल्प देखाइनेछ</string>
+    <string name="floating_text_selection_activity_label">ErikrafT Drop मार्फत पठाउनुहोस्</string>
     <string name="settings_theme_title">थीम</string>
     <string-array name="darkmode_entries">
         <item>पूर्वनिर्धारित प्रणाली</item>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">voltooien</string>
     <string name="onboarding_choose_server">Kies een serveradres</string>
     <string name="onboarding_choose_server_short">kies een server</string>
-    <string name="onboarding_choose_server_description">Deze app is een geoptimaliseerde client voor de webapps Snapdrop en PairDrop.\nKies een van de volgende instanties of specificeer een aangepaste url om verbinding mee te maken.\n\nOpmerking: Kies dezelfde URL op alle apparaten.</string>
+    <string name="onboarding_choose_server_description">Deze app is een geoptimaliseerde client voor de webapps ErikrafT Drop en PairDrop.\nKies een van de volgende instanties of specificeer een aangepaste url om verbinding mee te maken.\n\nOpmerking: Kies dezelfde URL op alle apparaten.</string>
     <string name="onboarding_storage_permission">Toegang tot bestanden</string>
     <string name="onboarding_storage_permission_description">Deze app is bedoeld voor het delen van bestanden. Daarom is toestemming tot bestanden vereist om deze te gebruiken.</string>
     <string name="onboarding_server_pairdrop_summary">(aanbevolen)\nKoppeling functie, overdracht via internet en focus op stabiliteit.</string>
@@ -47,10 +47,10 @@
     <string name="keep_on_summary">(Aanbevolen) Veel apparaten hebben problemen met onderbroken overdrachten waneer het scherm wordt uitgeschakeld</string>
     <string name="keep_on_title">Houd het scherm aan tijdens de overdracht</string>
     <string name="floating_text_selection_title">Zwevende-tekstselectie</string>
-    <string name="floating_text_selection_summary">Bij het selecteren van tekst in andere apps wordt een optie \"Verstuur met Snapdrop\" getoond</string>
+    <string name="floating_text_selection_summary">Bij het selecteren van tekst in andere apps wordt een optie \"Verstuur met ErikrafT Drop\" getoond</string>
     <string name="show_connectivity_card_title">Waarschuwing voor verbinding</string>
     <string name="show_connectivity_card_summary"> Een waarschuwing weergeven wanneer je niet verbonden bent met een WiFi-netwerk</string>
-    <string name="floating_text_selection_activity_label">Verstuur met Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Verstuur met ErikrafT Drop</string>
     <string name="permission_not_granted">verleen de benodigde rechten</string>
     <string name="permission_not_granted_fallback">verleen de benodigde toestemming handmatig</string>
     <string name="open_settings">instellingen</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">zakończ</string>
     <string name="onboarding_choose_server">Wybierz adres serwera</string>
     <string name="onboarding_choose_server_short">wybierz serwer</string>
-    <string name="onboarding_choose_server_description">Ta aplikacja jest zoptymalizowanym klientem aplikacji webowych Snapdrop i PairDrop.\nWybierz jedną z następujących instancji lub określ niestandardowy adres url do połączenia\n\nUwaga: musisz wybrać ten sam URL na wszystkich urządzeniach.</string>
+    <string name="onboarding_choose_server_description">Ta aplikacja jest zoptymalizowanym klientem aplikacji webowych ErikrafT Drop i PairDrop.\nWybierz jedną z następujących instancji lub określ niestandardowy adres url do połączenia\n\nUwaga: musisz wybrać ten sam URL na wszystkich urządzeniach.</string>
     <string name="onboarding_storage_permission">Uprawnienia do przechowywania danych</string>
     <string name="onboarding_storage_permission_description">Ta aplikacja jest narzędziem udostępniania plików. W związku z tym wymagane jest pozwolenie na przechowywanie plików, aby z niej korzystać.</string>
     <string name="onboarding_server_pairdrop_summary">(zalecane)\nFunkcja parowania, transfer Internetu i koncentracja na stabilności.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Zalecane) Wiele urządzeń ma problemy z przerywaniem transferu po wyłączeniu ekranu</string>
     <string name="keep_on_title">Pozostaw włączony ekran podczas przesyłania</string>
     <string name="floating_text_selection_title">Wybór pływającego tekstu</string>
-    <string name="floating_text_selection_summary">Podczas wybierania tekstu w innych aplikacjach zostanie wyświetlona opcja \"Wyślij za pomocą Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Podczas wybierania tekstu w innych aplikacjach zostanie wyświetlona opcja \"Wyślij za pomocą ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Ostrzeżenie o połączeniu</string>
     <string name="show_connectivity_card_summary"> Pokaż ostrzeżenie, gdy nie jesteś połączony z siecią WiFi</string>
-    <string name="floating_text_selection_activity_label">Wyślij przez Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Wyślij przez ErikrafT Drop</string>
     <string name="permission_not_granted">Proszę udzielić odpowiednich uprawnień</string>
     <string name="permission_not_granted_fallback">udziel niezbędnych uprawnień ręcznie</string>
     <string name="open_settings">otwórz ustawienia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_long">Sobre Snapdrop &amp; PairDrop para Android</string>
+    <string name="app_name_long">Sobre ErikrafT Drop &amp; PairDrop para Android</string>
     <string name="app_name_slogan">Transfira arquivos perfeitamente entre todos os seus dispositivos.</string>
     <string name="err_no_browser">Não foi possível abrir o navegador</string>
     <string name="err_no_app">Nenhum app instalado que pode abrir este arquivo</string>
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">terminar</string>
     <string name="onboarding_choose_server">Escolha o endereço do servidor</string>
     <string name="onboarding_choose_server_short">escolher servidor</string>
-    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o Snapdrop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma url personalizada para se conectar.\n\nNota: Você tem que escolher a mesma URL em todos os dispositivos.</string>
+    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o ErikrafT Drop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma url personalizada para se conectar.\n\nNota: Você tem que escolher a mesma URL em todos os dispositivos.</string>
     <string name="onboarding_storage_permission">Permissão de armazenamento</string>
     <string name="onboarding_storage_permission_description">Este aplicativo é usado para compartilhamento de arquivos. Portanto, a permissão de armazenamento é necessária para usá-lo.</string>
     <string name="onboarding_server_pairdrop_summary">(recomendado)\nrecurso de emparelhamento, transferência de internet e foco na estabilidade.</string>
@@ -34,7 +34,7 @@
     <string name="retry">repetir</string>
     <!-- Settings / About -->
     <string name="home_as_up_indicator_about">Informações sobre o \'app\'</string>
-    <string name="title_activity_about">Sobre Snapdrop &amp; PairDrop para Android</string>
+    <string name="title_activity_about">Sobre ErikrafT Drop &amp; PairDrop para Android</string>
     <string name="pref_about_title">Sobre este \'app\'</string>
     <string name="view_downloads">Ver downloads</string>
     <string name="pref_category_settings">Configurações</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Recomendado) Muitos dispositivos têm problemas com transferências interrompidas quando a tela for desligada</string>
     <string name="keep_on_title">Manter a tela ligada durante a transferência</string>
     <string name="floating_text_selection_title">Seleção de texto flutuante</string>
-    <string name="floating_text_selection_summary">Ao selecionar texto em outros apps, será exibida uma opção \"Enviar via Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Ao selecionar texto em outros apps, será exibida uma opção \"Enviar via ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Aviso de conectividade</string>
     <string name="show_connectivity_card_summary"> Mostra um aviso quando você não está conectado a uma rede Wi-Fi</string>
-    <string name="floating_text_selection_activity_label">Enviar via Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Enviar via ErikrafT Drop</string>
     <string name="permission_not_granted">Por favor, conceda as permissões necessárias</string>
     <string name="permission_not_granted_fallback">por favor, conceda a permissão necessária manualmente</string>
     <string name="open_settings">Abrir configurações</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -22,8 +22,8 @@
     <string name="keep_on_summary">(Recomendado) Muitos dispositivos têm problemas com transferências interrompidas quando a tela é desligada</string>
     <string name="keep_on_title">Mantenha a tela ligada durante a transferência</string>
     <string name="floating_text_selection_title">Seleção de texto flutuante</string>
-    <string name="floating_text_selection_summary">Ao selecionar texto em outras aplicações, será exibida uma opção \"Enviar com Snapdrop\"</string>
-    <string name="floating_text_selection_activity_label">Enviar com o Snapdrop</string>
+    <string name="floating_text_selection_summary">Ao selecionar texto em outras aplicações, será exibida uma opção \"Enviar com ErikrafT Drop\"</string>
+    <string name="floating_text_selection_activity_label">Enviar com o ErikrafT Drop</string>
     <string name="settings_theme_title">Tema</string>
     <string-array name="darkmode_entries">
         <item>Padrão do Sistema</item>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -9,7 +9,7 @@
     <string name="onboarding_button_grant">Acordă permisiuni</string>
     <string name="onboarding_button_finish">Finalizare</string>
     <string name="onboarding_choose_server">Alege o adresă de server</string>
-    <string name="onboarding_choose_server_description">Această aplicație este un client optimizat pentru aplicația web Snapdrop și PairDrop.\nAlege una dintre următoarele instanțe sau specifică un URL personalizat la care să te conectezi.\n\nNotă: Trebuie să alegeți același URL pe toate dispozitivele.</string>
+    <string name="onboarding_choose_server_description">Această aplicație este un client optimizat pentru aplicația web ErikrafT Drop și PairDrop.\nAlege una dintre următoarele instanțe sau specifică un URL personalizat la care să te conectezi.\n\nNotă: Trebuie să alegeți același URL pe toate dispozitivele.</string>
     <string name="onboarding_storage_permission">Permisiuni pentru stocare</string>
     <string name="onboarding_storage_permission_description">Această aplicație este pentru partajări. De aceea sunt necesare permisiuni pentru stocare.</string>
     <string name="onboarding_server_pairdrop_summary">(recomandat)\nFuncția de asociere, transfer internet și concentrare asupra stabilității.</string>
@@ -42,8 +42,8 @@
     <string name="keep_on_summary">(Recomandat) Multe dispozitive au probleme cu transferurile întrerupte atunci când ecranul se oprește</string>
     <string name="keep_on_title">Păstrează ecranul pornit în timpul transferului</string>
     <string name="floating_text_selection_title">Selecție de text plutitoare</string>
-    <string name="floating_text_selection_summary">La selectarea textului în alte aplicații, o opțiune \"Trimite cu Snapdrop\" va fi afișată</string>
-    <string name="floating_text_selection_activity_label">Trimite prin Snapdrop</string>
+    <string name="floating_text_selection_summary">La selectarea textului în alte aplicații, o opțiune \"Trimite cu ErikrafT Drop\" va fi afișată</string>
+    <string name="floating_text_selection_activity_label">Trimite prin ErikrafT Drop</string>
     <string name="permission_not_granted">vă rugăm să acordați permisiunea necesară</string>
     <string name="permission_not_granted_fallback">vă rugăm să acordați manual permisiunea necesară</string>
     <string name="open_settings">deschide setări</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">Завершить</string>
     <string name="onboarding_choose_server">Выберите адрес сервера</string>
     <string name="onboarding_choose_server_short">Выберите сервер</string>
-    <string name="onboarding_choose_server_description">Это приложение оптимизировано для веб-приложений Snapdrop и PairDrop.\nВыберите один из следующих экземпляров или укажите пользовательский URL для подключения.\n\nПримечание: вы должны выбрать один и тот же URL на всех устройствах.</string>
+    <string name="onboarding_choose_server_description">Это приложение оптимизировано для веб-приложений ErikrafT Drop и PairDrop.\nВыберите один из следующих экземпляров или укажите пользовательский URL для подключения.\n\nПримечание: вы должны выбрать один и тот же URL на всех устройствах.</string>
     <string name="onboarding_storage_permission">Разрешение на работу с файлами</string>
     <string name="onboarding_storage_permission_description">Это приложение является утилитой для обмена файлами. Поэтому для его использования требуется разрешение на работу с файлами.</string>
     <string name="onboarding_server_pairdrop_summary">(Рекомендуется)\nВозможность сопряжения, интернет-передача и фокус на стабильности.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Рекомендуется) На многих устройствах наблюдаются проблемы с прерыванием передачи при выключенном экране</string>
     <string name="keep_on_title">Не выключать экран во время передачи</string>
     <string name="floating_text_selection_title">Поделиться выделенным текстом</string>
-    <string name="floating_text_selection_summary">При попытке поделиться текстом будет предложена отправка через \"Snapdrop\"</string>
+    <string name="floating_text_selection_summary">При попытке поделиться текстом будет предложена отправка через \"ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Предупреждение о подключении</string>
     <string name="show_connectivity_card_summary">Показывать предупреждение, когда вы не подключены к сети WiFi</string>
-    <string name="floating_text_selection_activity_label">Отправить в Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Отправить в ErikrafT Drop</string>
     <string name="permission_not_granted">Пожалуйста, дайте необходимое разрешение</string>
     <string name="permission_not_granted_fallback">Пожалуйста, предоставьте необходимое разрешение вручную</string>
     <string name="open_settings">Открыть настройки</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">dokončiť</string>
     <string name="onboarding_choose_server">Vyberte adresu serveru</string>
     <string name="onboarding_choose_server_short">vybrať server</string>
-    <string name="onboarding_choose_server_description">Táto aplikácia je optimalizovaný klient pre webové aplikácie Snapdrop a PairDrop.\nVyberte si jednu z nasledujúcich inštancií alebo špecifikuje vlastnú url na pripojenie.\n\nPoznámka: Musíte si vybrať rovnakú URL na všetkých zariadeniach.</string>
+    <string name="onboarding_choose_server_description">Táto aplikácia je optimalizovaný klient pre webové aplikácie ErikrafT Drop a PairDrop.\nVyberte si jednu z nasledujúcich inštancií alebo špecifikuje vlastnú url na pripojenie.\n\nPoznámka: Musíte si vybrať rovnakú URL na všetkých zariadeniach.</string>
     <string name="onboarding_storage_permission">Povolenie prístupu k súborom</string>
     <string name="onboarding_storage_permission_description">Táto aplikácia je nástroj na zdieľanie súborov. Preto je pre použitie vyžadované povolenie prístupu k súborom.</string>
     <string name="onboarding_server_pairdrop_summary">(odporúčané)\nPárovacia funkcia, prenos cez internet a zameranie na stabilitu.</string>
@@ -47,10 +47,10 @@
     <string name="keep_on_summary">(Odporúčané) Mnohé zariadenia majú problémy s prerušovaním prenosov, keď majú vypnutú obrazovku</string>
     <string name="keep_on_title">Nechať obrazovku zapnutú počas prenosu</string>
     <string name="floating_text_selection_title">Výber plávajúceho textu</string>
-    <string name="floating_text_selection_summary">Keď budete označovať text v iných aplikáciách, zobrazí sa možnosť \"Poslať cez Snapdrop\"</string>
+    <string name="floating_text_selection_summary">Keď budete označovať text v iných aplikáciách, zobrazí sa možnosť \"Poslať cez ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Upozornení na pripojení</string>
     <string name="show_connectivity_card_summary"> Zobrazenie upozornení, ak nie ste pripojení k sieti Wi-Fi</string>
-    <string name="floating_text_selection_activity_label">Poslať cez Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Poslať cez ErikrafT Drop</string>
     <string name="permission_not_granted">prosím udeľte potrebné povolenia</string>
     <string name="permission_not_granted_fallback">prosím udeľte potrebné povolenia manuálne</string>
     <string name="open_settings">otvoriť nastavenia</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">konec</string>
     <string name="onboarding_choose_server">Izberite naslov strežnika</string>
     <string name="onboarding_choose_server_short">izberite strežnik</string>
-    <string name="onboarding_choose_server_description">Ta aplikacija je optimiziran odjemalec za spletni aplikaciji Snapdrop in PairDrop.\nIzberite enega od naslednjih primerov ali pa vnesite lasten URL za povezavo.\n\nOpomba: v vseh napravah morate izbrati isti URL.</string>
+    <string name="onboarding_choose_server_description">Ta aplikacija je optimiziran odjemalec za spletni aplikaciji ErikrafT Drop in PairDrop.\nIzberite enega od naslednjih primerov ali pa vnesite lasten URL za povezavo.\n\nOpomba: v vseh napravah morate izbrati isti URL.</string>
     <string name="onboarding_storage_permission">Dovoljenje za shrambo</string>
     <string name="onboarding_storage_permission_description">Ta aplikacija je orodje za deljenje datotek. Zato je potrebno dovoljenje za shranjevanje, da jo lahko uporabljate.</string>
     <string name="onboarding_server_pairdrop_summary">(priporočeno)\nZnačilnosti povezovanja, prenosa prek interneta in poudarek na stabilnosti.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Priporočeno) Številne naprave imajo težave s prekinitvijo prenosa, ko se zaslon izklopi</string>
     <string name="keep_on_title">Med prenosom ne izklopi zaslona</string>
     <string name="floating_text_selection_title">Lebdeči izbor besedila</string>
-    <string name="floating_text_selection_summary">Pri izbiri besedila v drugih aplikacijah se bo prikazala možnost \"Pošlji s Snapdrop-om\"</string>
+    <string name="floating_text_selection_summary">Pri izbiri besedila v drugih aplikacijah se bo prikazala možnost \"Pošlji s ErikrafT Drop-om\"</string>
     <string name="show_connectivity_card_title">Opozorilo o povezljivosti</string>
     <string name="show_connectivity_card_summary"> Opozori me, če nisem povezan z WiFi omrežjem</string>
-    <string name="floating_text_selection_activity_label">Pošlji s Snapdrop-om</string>
+    <string name="floating_text_selection_activity_label">Pošlji s ErikrafT Drop-om</string>
     <string name="permission_not_granted">prosimo omogočite potrebna dovoljenja</string>
     <string name="permission_not_granted_fallback">prosimo omogočite potrebna dovoljenja ročno</string>
     <string name="open_settings">odpri nastavitve</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">bitir</string>
     <string name="onboarding_choose_server">Server adresi seçin</string>
     <string name="onboarding_choose_server_short">sunucu seçin</string>
-    <string name="onboarding_choose_server_description">Bu uygulama Snapdrop ve PairDrop web uygulamaları için optimize edilmiş bir istemcidir.\nAşağıdaki örneklerden birini seçin veya bağlanılacak özel bir URL belirtin.\n\nNot: Tüm cihazlarda aynı URL\'yi seçmelisiniz.</string>
+    <string name="onboarding_choose_server_description">Bu uygulama ErikrafT Drop ve PairDrop web uygulamaları için optimize edilmiş bir istemcidir.\nAşağıdaki örneklerden birini seçin veya bağlanılacak özel bir URL belirtin.\n\nNot: Tüm cihazlarda aynı URL\'yi seçmelisiniz.</string>
     <string name="onboarding_storage_permission">Depolama izni</string>
     <string name="onboarding_storage_permission_description">Bu uygulama bir dosya aktarım aracıdır. Uygulamayı kullanabilmek için depolama izni gerekir.</string>
     <string name="onboarding_server_pairdrop_summary">(önerilir)\nEşleştirme özelliği, internet aktarımı ve stabilite üzerine odaklı.</string>
@@ -49,10 +49,10 @@
     <string name="keep_on_summary">(Önerilir) Bir çok cihaz ekranın transfer anında kapanması sebebiyle problem yaşamakta</string>
     <string name="keep_on_title">Transfer sırasında ekranı açık tut</string>
     <string name="floating_text_selection_title">Kayan metin seçimi</string>
-    <string name="floating_text_selection_summary">Diğer uygulamalarda metin seçerken \"Snapdrop ile gönder\" seçeneği gösterilecek</string>
+    <string name="floating_text_selection_summary">Diğer uygulamalarda metin seçerken \"ErikrafT Drop ile gönder\" seçeneği gösterilecek</string>
     <string name="show_connectivity_card_title">Bağlantı uyarısı</string>
     <string name="show_connectivity_card_summary"> Bir WiFi ağına bağlı olmadığında uyarı göster</string>
-    <string name="floating_text_selection_activity_label">Snapdrop ile gönder</string>
+    <string name="floating_text_selection_activity_label">ErikrafT Drop ile gönder</string>
     <string name="permission_not_granted">lütfen gerekli izni onaylayın</string>
     <string name="permission_not_granted_fallback">lütfen gerekli izni manuel olarak onaylayın</string>
     <string name="open_settings">ayarları aç</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">завершити</string>
     <string name="onboarding_choose_server">Виберіть адресу сервера</string>
     <string name="onboarding_choose_server_short">вибрати сервер</string>
-    <string name="onboarding_choose_server_description">Цей застосунок є оптимізованим клієнтом для вебзастосунків Snapdrop і PairDrop.\nВиберіть один із наведених нижче екземплярів або вкажіть спеціальну URL-адресу для підключення.\n\nПримітка: Вам потрібно вибрати однакову URL-адресу на всіх пристроях.</string>
+    <string name="onboarding_choose_server_description">Цей застосунок є оптимізованим клієнтом для вебзастосунків ErikrafT Drop і PairDrop.\nВиберіть один із наведених нижче екземплярів або вкажіть спеціальну URL-адресу для підключення.\n\nПримітка: Вам потрібно вибрати однакову URL-адресу на всіх пристроях.</string>
     <string name="onboarding_storage_permission">Дозвіл на зберігання</string>
     <string name="onboarding_storage_permission_description">Цей застосунок є засобом для обміну файлами. Тому для його використання потрібен дозвіл на зберігання.</string>
     <string name="onboarding_server_pairdrop_summary">(рекомендовано)\nФункція створення пари, передавання через інтернет та зосередженість на стабільності.</string>
@@ -52,10 +52,10 @@
     <string name="keep_on_summary">(Рекомендується) На багатьох пристроях спостерігаються проблеми з перериванням передачі при вимкненому екрані</string>
     <string name="keep_on_title">Не вимикати екран під час передачі</string>
     <string name="floating_text_selection_title">Поділитись виділеним текстом</string>
-    <string name="floating_text_selection_summary">При виборі тексту в інших програмах буде запропоновано опцію \"Надіслати за допомогою Snapdrop\"</string>
+    <string name="floating_text_selection_summary">При виборі тексту в інших програмах буде запропоновано опцію \"Надіслати за допомогою ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Попередження про підключення</string>
     <string name="show_connectivity_card_summary"> Показувати попередження, коли ви не підключені до мережі WiFi</string>
-    <string name="floating_text_selection_activity_label">Надіслати за допомогою Snapdrop</string>
+    <string name="floating_text_selection_activity_label">Надіслати за допомогою ErikrafT Drop</string>
     <string name="permission_not_granted">будь ласка, надайте необхідний дозвіл</string>
     <string name="permission_not_granted_fallback">будь ласка, надайте необхідний дозвіл вручну</string>
     <string name="open_settings">відкрити налаштування</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -22,8 +22,8 @@
     <string name="keep_on_summary">(Khuyến khích) Một số thiết bị trong lúc truyền sẽ bị ngắt nếu màn hình bị tắt</string>
     <string name="keep_on_title">Giữ màn hình bật khi đang truyền</string>
     <string name="floating_text_selection_title">Hộp thoại nổi khi bôi đen chữ</string>
-    <string name="floating_text_selection_summary">Khi bôi đen văn bản trên ứng dụng khác, lựa chọn \"Gửi bằng Snapdrop\" sẽ hiện lên</string>
-    <string name="floating_text_selection_activity_label">Gửi bằng Snapdrop</string>
+    <string name="floating_text_selection_summary">Khi bôi đen văn bản trên ứng dụng khác, lựa chọn \"Gửi bằng ErikrafT Drop\" sẽ hiện lên</string>
+    <string name="floating_text_selection_activity_label">Gửi bằng ErikrafT Drop</string>
     <string name="settings_theme_title">Giao diện</string>
     <string-array name="darkmode_entries">
         <item>Mặc định theo hệ thống</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@
     <string name="onboarding_button_finish">完成</string>
     <string name="onboarding_choose_server">选择一个服务器地址</string>
     <string name="onboarding_choose_server_short">选择服务器</string>
-    <string name="onboarding_choose_server_description">这个应用程序是适用于 Snapdrop 和 PairDrop 的 Web 应用程序的优化客户端。\n选择以下实例之一或指定要连接的自定义URL。\n\n注意：您必须在所有设备上选择相同的 URL。</string>
+    <string name="onboarding_choose_server_description">这个应用程序是适用于 ErikrafT Drop 和 PairDrop 的 Web 应用程序的优化客户端。\n选择以下实例之一或指定要连接的自定义URL。\n\n注意：您必须在所有设备上选择相同的 URL。</string>
     <string name="onboarding_storage_permission">存储权限</string>
     <string name="onboarding_storage_permission_description">此应用是一个共享文件的工具。因此，需要存储权限才能使用。</string>
     <string name="onboarding_server_pairdrop_summary">(推荐)\n配对功能、互联网传输并侧重于稳定性。</string>
@@ -47,10 +47,10 @@
     <string name="keep_on_summary">(推荐) 若遇到熄屏时传输中断的问题，请启用该项</string>
     <string name="keep_on_title">传输时保持屏幕开启</string>
     <string name="floating_text_selection_title">浮动文字选择</string>
-    <string name="floating_text_selection_summary">使用其他APP选中文本时，显示“使用Snapdrop发送”选项</string>
+    <string name="floating_text_selection_summary">使用其他APP选中文本时，显示“使用ErikrafT Drop发送”选项</string>
     <string name="show_connectivity_card_title">连接警告</string>
     <string name="show_connectivity_card_summary"> 当您没有连接到 WiFi 网络时显示警告</string>
-    <string name="floating_text_selection_activity_label">使用Snapdrop发送</string>
+    <string name="floating_text_selection_activity_label">使用ErikrafT Drop发送</string>
     <string name="permission_not_granted">请授予必要的权限</string>
     <string name="permission_not_granted_fallback">请手动授予必要的权限</string>
     <string name="open_settings">打开设定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -10,7 +10,7 @@
     <string name="onboarding_button_finish">完成</string>
     <string name="onboarding_choose_server">選擇一個伺服器位址</string>
     <string name="onboarding_choose_server_short">選擇伺服器</string>
-    <string name="onboarding_choose_server_description">這個應用程式是專為 Web 應用程式 Snapdrop 和 PairDrop 最佳化的用戶端。\n選擇以下執行個體或指定一個自訂 URL 以進行連線。\n\n注意：您必須在所有裝置上選擇相同的 URL。</string>
+    <string name="onboarding_choose_server_description">這個應用程式是專為 Web 應用程式 ErikrafT Drop 和 PairDrop 最佳化的用戶端。\n選擇以下執行個體或指定一個自訂 URL 以進行連線。\n\n注意：您必須在所有裝置上選擇相同的 URL。</string>
     <string name="onboarding_storage_permission">儲存空間權限</string>
     <string name="onboarding_storage_permission_description">這是一個用於檔案分享的公用程式，因此，若要使用它，需要授予儲存空間權限。</string>
     <string name="onboarding_server_pairdrop_summary">(建議)\n配對功能，網際網路傳輸並專注於穩定性。</string>
@@ -51,10 +51,10 @@
     <string name="keep_on_summary">如果遇到螢幕休眠而中斷傳輸請開啟這個選項</string>
     <string name="keep_on_title">傳輸時保持螢幕開啟</string>
     <string name="floating_text_selection_title">浮動式文字選取</string>
-    <string name="floating_text_selection_summary">使用其他應用程式選取文字時，顯示「使用 Snapdrop 傳送」選項</string>
+    <string name="floating_text_selection_summary">使用其他應用程式選取文字時，顯示「使用 ErikrafT Drop 傳送」選項</string>
     <string name="show_connectivity_card_title">連線能力警告</string>
     <string name="show_connectivity_card_summary"> 在未連線至 WiFi 網路時顯示警告</string>
-    <string name="floating_text_selection_activity_label">使用 Snapdrop 傳送</string>
+    <string name="floating_text_selection_activity_label">使用 ErikrafT Drop 傳送</string>
     <string name="permission_not_granted">請授予必要權限</string>
     <string name="permission_not_granted_fallback">請手動授予必要權限</string>
     <string name="open_settings">開啟設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="onboarding_button_finish">finish</string>
     <string name="onboarding_choose_server">Choose a server address</string>
     <string name="onboarding_choose_server_short">choose server</string>
-    <string name="onboarding_choose_server_description">This app is an optimized client for local file sharing.\n\nNote: You have to choose the same URL on all devices.</string>
+    <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
     <string name="onboarding_server_pairdrop_summary">(recommended)\nPairing feature, internet transfer and focus on stability.</string>
@@ -57,10 +57,10 @@
     <string name="keep_on_summary">(Recommended) Many devices have problems with transfers being interrupted when the screen turns off</string>
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
-    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with PairDrop\" will be shown</string>
+    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with ErikrafT Drop\" will be shown</string>
     <string name="show_connectivity_card_title">Connectivity warning</string>
     <string name="show_connectivity_card_summary"> Show a warning when you are not connected with a WiFi network</string>
-    <string name="floating_text_selection_activity_label">Send with PairDrop</string>
+    <string name="floating_text_selection_activity_label">Send with ErikrafT Drop</string>
     <string name="permission_not_granted">please grant the necessary permission</string>
     <string name="permission_not_granted_fallback">please grant the necessary permission manually</string>
     <string name="open_settings">open settings</string>

--- a/app/src/main/res/values/strings_not_translatable.xml
+++ b/app/src/main/res/values/strings_not_translatable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- baseURL -->
-    <string name="baseURL" translatable="false">https://snapdrop.net/</string>
+    <string name="baseURL" translatable="false">https://drop.erikraft.com/</string>
     <!-- onboarding - suggested instances -->
     <string name="onboarding_server_pairdrop" translatable="false">https://pairdrop.net</string>
     <string name="onboarding_server_snapdrop" translatable="false">https://snapdrop.net</string>


### PR DESCRIPTION
## Summary
- point the support preference, README, and in-app donation button to the ErikrafT Ko-fi page
- update the about dialog to credit PairDrop and ErikrafT Drop, open the new GitHub and X links, rename the social button to 𝕏｜Twitter, and drop the Crowdin shortcut
- make drop.erikraft.com the default server string, adjust legacy Snapdrop detection, and localize the Portuguese about title for the new branding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e44e8cd5dc832aa25628790c6c5bfb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Server onboarding now triggers when the base URL starts with the snapdrop domain.
  - Broader PairDrop detection, including drop.erikraft.com.

- Chores
  - Rebranded Snapdrop/PairDrop references to ErikrafT Drop across the app and many localizations.
  - Default base URL updated to https://drop.erikraft.com.
  - Donation moved to Ko‑fi; social links updated (X/Twitter).
  - Settings/About credits and action buttons refreshed.
  - Share/Tweet and donate links updated.

- Documentation
  - README support link now points to Ko‑fi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->