### PR TITLE
Remove wear flavor configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,22 @@ android {
         }
     }
 
+    flavorDimensions "device"
+
+    productFlavors {
+        mobile {
+            dimension "device"
+        }
+
+        tv {
+            dimension "device"
+        }
+
+        xr {
+            dimension "device"
+        }
+    }
+
     buildFeatures {
         viewBinding true
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,11 +23,6 @@
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
-    <uses-feature
-        android:name="android.software.leanback"
-        android:required="false" />
-
-
     <supports-screens
         android:anyDensity="true"
         android:largeScreens="true"
@@ -38,10 +33,10 @@
     <application
         android:name=".SnapdropApplication"
         android:allowBackup="false"
-        android:banner="@drawable/tv_banner"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:isGame="false"
         android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
@@ -82,7 +77,6 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/tv/AndroidManifest.xml
+++ b/app/src/tv/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+
+    <application
+        android:banner="@drawable/tv_banner"
+        tools:replace="android:banner">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/tv/res/layout/activity_main.xml
+++ b/app/src/tv/res/layout/activity_main.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/colorBackground"
+            app:subtitleCentered="true"
+            app:titleCentered="true" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/pullToRefresh"
+        style="@style/AppTheme"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:focusable="false"
+        android:descendantFocusability="afterDescendants"
+        tools:context=".MainActivity">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:focusable="false">
+
+                <ImageView
+                    android:id="@+id/load_animator"
+                    android:layout_width="120dp"
+                    android:layout_height="120dp"
+                    app:tint="@color/colorAccent"
+                    tools:src="@drawable/snapdrop_anim" />
+            </LinearLayout>
+
+            <WebView
+                android:id="@+id/webview"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_below="@id/connectivity_card"
+                android:alpha="0"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                android:scrollbars="none"
+                android:textCursorDrawable="@color/colorAccent" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/connectivity_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:layout_marginTop="0dp"
+                android:focusable="true"
+                android:foregroundGravity="center"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/colorAccent"
+                app:strokeColor="@android:color/transparent"
+                tools:visibility="visible">
+
+                <TextView
+                    android:id="@+id/connectivity_textview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:drawablePadding="10dp"
+                    android:text="@string/error_network_no_wifi"
+                    android:textAlignment="center"
+                    android:textColor="@color/textColorWhite"
+                    android:textSize="16sp"
+                    app:drawableStartCompat="@drawable/phonelink_off" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:id="@+id/no_connection_screen"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorBackground"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/no_connection_textview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:drawablePadding="10dp"
+                    android:text="@string/error_network_offline"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="16sp"
+                    app:drawableTopCompat="@drawable/network_off" />
+
+                <Button
+                    android:id="@+id/retry_button"
+                    style="@style/Widget.Material3.Button.ElevatedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30dp"
+                    android:focusable="true"
+                    android:nextFocusUp="@id/webview"
+                    android:text="@string/retry"
+                    android:textColor="@android:color/darker_gray" />
+
+                <Button
+                    android:id="@+id/url_change_button"
+                    style="@style/Widget.Material3.Button.ElevatedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:focusable="true"
+                    android:nextFocusUp="@id/retry_button"
+                    android:text="@string/onboarding_choose_server_short"
+                    android:textColor="@android:color/darker_gray"
+                    android:visibility="gone" />
+            </LinearLayout>
+        </RelativeLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</LinearLayout>

--- a/app/src/xr/AndroidManifest.xml
+++ b/app/src/xr/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.vr.headtracking"
+        android:required="false" />
+</manifest>


### PR DESCRIPTION
## Summary
- add a device flavor dimension with dedicated mobile, tv, and xr variants, dropping the limited wear option
- move TV- and XR-specific configuration into flavor manifests and provide a DPAD-friendly TV layout

## Testing
- not run (SDK location not configured in container)


------
https://chatgpt.com/codex/tasks/task_e_68e63e096a3c832ab994916aa84eb88b