### PR TITLE
Fix Android Web-to-App File Transfer & Verify Target API

### DIFF
--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -106,6 +106,7 @@ try {
 
 //catch chunks
 try {
+    Peer.prototype._oFH = Peer.prototype._onFileHeader;
     Peer.prototype._onFileHeader = function (header) {
         this._isToAndroidBase64 = header.mime.startsWith("text/") || header.name.toLowerCase().endsWith(".txt");
         let mimeInfo = this._isToAndroidBase64 ? "base64:" + header.mime : header.mime;
@@ -113,6 +114,7 @@ try {
         this._oFH(header);
     };
 
+    Peer.prototype._oCR = Peer.prototype._onChunkReceived;
     Peer.prototype._onChunkReceived = function (chunk) {
         let decoder = new TextDecoder('iso-8859-1');
         let rawString = decoder.decode(chunk);

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -42,6 +42,7 @@ public class JavaScriptInterface {
 
     @JavascriptInterface
     public void newFile(final String fileName, final String mimeType, final String fileSize) throws IOException {
+        Log.i("DropAndroidJS", "Transfer Start: Receiving file. fileName=" + fileName + ", mimeType=" + mimeType + ", fileSize=" + fileSize);
         String finalMime = mimeType;
         if (mimeType.startsWith("base64:")) {
             isBase64 = true;
@@ -52,10 +53,12 @@ public class JavaScriptInterface {
 
         final FileWrapper fileWrapper = createFileWrapper(fileName, finalMime);
         if (fileWrapper == null) {
+            Log.e("DropAndroidJS", "Transfer Failure: Missing storage permissions for " + fileName);
             throw new IOException("Missing storage permissions");
         }
         fileOutputStream = UriUtils.openOutputStream(fileWrapper.getUri(), context.getApplicationContext());
         if (fileOutputStream == null) {
+            Log.e("DropAndroidJS", "Transfer Failure: Cannot write target file: " + fileWrapper.getUri());
             throw new IOException("Cannot write target file");
         }
         fileHeader = new FileHeader(fileName, finalMime, fileSize, fileWrapper);
@@ -102,24 +105,37 @@ public class JavaScriptInterface {
     @JavascriptInterface
     public void onBytes(final String dec) throws IOException {
         if (fileOutputStream == null) {
+            Log.e("DropAndroidJS", "Transfer Failure: fileOutputStream is null during onBytes");
             return;
         }
-        // https://stackoverflow.com/questions/27034897/is-there-a-way-to-pass-an-arraybuffer-from-javascript-to-java-on-android
-        byte[] bytes;
-        if (isBase64) {
-            bytes = Base64.decode(dec, Base64.NO_WRAP);
-        } else {
-            bytes = dec.getBytes(StandardCharsets.ISO_8859_1);
+        try {
+            // https://stackoverflow.com/questions/27034897/is-there-a-way-to-pass-an-arraybuffer-from-javascript-to-java-on-android
+            byte[] bytes;
+            if (isBase64) {
+                bytes = Base64.decode(dec, Base64.NO_WRAP);
+            } else {
+                bytes = dec.getBytes(StandardCharsets.ISO_8859_1);
+            }
+            fileOutputStream.write(bytes);
+            fileOutputStream.flush();
+        } catch (IOException e) {
+            Log.e("DropAndroidJS", "Transfer Failure: Exception during write of file bytes", e);
+            throw e;
         }
-        fileOutputStream.write(bytes);
-        fileOutputStream.flush();
     }
 
     @JavascriptInterface
     public void saveDownloadFileName(final String name, final String size) throws IOException {
-        fileOutputStream.flush();
-        fileOutputStream.close();
-        isBase64 = false;
+        Log.i("DropAndroidJS", "Transfer Complete: Saved file " + name + " (size: " + size + ")");
+        try {
+            fileOutputStream.flush();
+            fileOutputStream.close();
+        } catch (IOException e) {
+            Log.e("DropAndroidJS", "Transfer Failure: Exception during flush/close of file output stream", e);
+            throw e;
+        } finally {
+            isBase64 = false;
+        }
 
         context.downloadFilesList.add(fileHeader);
     }
@@ -175,6 +191,7 @@ public class JavaScriptInterface {
 
     @JavascriptInterface
     public void ignoreClickedListener() {
+        Log.i("DropAndroidJS", "Transfer Canceled: Ignore clicked by user.");
         IOUtils.closeStreamQuietly(fileOutputStream);
         isBase64 = false;
         if (fileHeader != null && fileHeader.file.delete()) {
@@ -187,6 +204,7 @@ public class JavaScriptInterface {
 
     @JavascriptInterface
     public void setProgress(final float progress) {
+        Log.d("DropAndroidJS", "Transfer Progress: " + progress);
         if (progress > 0) {
             context.transfer.set(true);
         } else {


### PR DESCRIPTION
Defines `_oFH` and `_oCR` on `Peer.prototype` before hooking into them within `init.js`. This resolves a JavaScript TypeError that crashed incoming transfers. Detailed lifecycle logging and error handling have been added to JavaScriptInterface.java. targetSdkVersion is verified to target the latest stable API 35 (Android 15), satisfying Google Play requirements.

---
*PR created automatically by Jules for task [16915981233108908411](https://jules.google.com/task/16915981233108908411) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-transfer handling and reliability.
  * Preserved file-header processing while continuing to report file metadata.
  * Improved error handling for failed writes and stream finalization.
  * Ensured transfer state is reset after completion or cancellation.
  * Added logging to help diagnose transfer progress and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->