### PR TITLE
Update support and donation links

### DIFF
--- a/app/src/main/java/com/erikraft/drop/SettingsFragment.java
+++ b/app/src/main/java/com/erikraft/drop/SettingsFragment.java
@@ -90,7 +90,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             storageHelper.onRestoreInstanceState(savedInstanceState);
         }
 
-        initUrlPreference(R.string.pref_support, "https://ko-fi.com/erikraft/");
+        initUrlPreference(R.string.pref_support, "https://biodrop.erikraft.com/donation.html");
 
         final Preference openSourceComponents = findPreference(getString(R.string.pref_about));
         openSourceComponents.setOnPreferenceClickListener(pref -> {
@@ -106,8 +106,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                             "with the Android client maintained at<br>" +
                             "<a href=\"https://github.com/erikraft/Drop-Android\">github.com/erikraft/Drop-Android</a><br><br>" +
                             "<big><b>" + getString(R.string.support_us) + "</b></big><br><br>" +
-                            getString(R.string.support_us_summary) + "<br>" +
-                            "<a href=\"https://ko-fi.com/erikraft/\">" + getString(R.string.read_more) + "</a>")
+                            getString(R.string.support_us_description) + "<br><br>" +
+                            "<b>" + getString(R.string.support_us_option_kofi) + "</b><br>" +
+                            "<a href=\"https://ko-fi.com/erikraft/\">https://ko-fi.com/erikraft/</a><br><br>" +
+                            "<b>" + getString(R.string.support_us_option_pix_kofi) + "</b><br>" +
+                            "<a href=\"https://biodrop.erikraft.com/donation.html\">" + getString(R.string.open_url) + "</a>")
                     .withAboutSpecial1("GitHub")
                     .withAboutSpecial2("Twitter/X")
                     .withListener(new AboutLibrariesListener() {

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -43,6 +43,9 @@
     <string name="components_summary">Toque para exibir</string>
     <string name="support_us">Nos ajude</string>
     <string name="support_us_summary">Veja, como você pode apoiar este projeto</string>
+    <string name="support_us_description">Ajude a manter o ErikrafT Drop™</string>
+    <string name="support_us_option_kofi">Ko-fi</string>
+    <string name="support_us_option_pix_kofi">PIX &amp; Ko-fi</string>
     <string name="read_more">Acesse mais informações</string>
     <string name="version">Versão</string>
     <string name="pref_device_name_title">Nome do dispositivo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -41,8 +41,11 @@
     <string name="pref_category_settings">Configurações</string>
     <string name="logs">Dados de Depuração</string>
     <string name="components_summary">Pressione para exibir</string>
-    <string name="support_us">Support us</string>
-    <string name="support_us_summary">See, how you can support this project</string>
+    <string name="support_us">Nos ajude</string>
+    <string name="support_us_summary">Veja como pode apoiar este projeto</string>
+    <string name="support_us_description">Ajude a manter o ErikrafT Drop™</string>
+    <string name="support_us_option_kofi">Ko-fi</string>
+    <string name="support_us_option_pix_kofi">PIX &amp; Ko-fi</string>
     <string name="read_more">read more</string>
     <string name="version">Versão</string>
     <string name="pref_device_name_title">Nome do Dispositivo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,9 @@
     <string name="components_summary">Tap to display</string>
     <string name="support_us">Support us</string>
     <string name="support_us_summary">See, how you can support this project</string>
+    <string name="support_us_description">Support ErikrafT Drop™ and help keep the project running.</string>
+    <string name="support_us_option_kofi">Ko-fi</string>
+    <string name="support_us_option_pix_kofi">PIX &amp; Ko-fi</string>
     <string name="read_more">read more</string>
     <string name="version">Version</string>
     <string name="pref_device_name_title">Device name</string>


### PR DESCRIPTION
This change updates the support options and donation destination in the ErikrafT Drop Android client.

1. Updates SettingsFragment.java to point the standalone 'Nos Ajude' R.string.pref_support preference directly to the PIX & Ko-fi donation page: https://biodrop.erikraft.com/donation.html
2. Modifies the 'About this app' dialog description in SettingsFragment.java to display both the existing Ko-fi link and the new PIX & Ko-fi donation link.
3. Defines appropriate localized strings for the donation details (description and support options) in values/strings.xml, values-pt-rBR/strings.xml, and values-pt-rPT/strings.xml.

---
*PR created automatically by Jules for task [10926639704777251405](https://jules.google.com/task/10926639704777251405) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the support link to the ErikrafT donation page.
  * Expanded the About section with support details and separate Ko-fi and PIX/Ko-fi donation options.

* **Localization**
  * Added and updated support-related translations in English and Portuguese (Brazil and Portugal).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->