### PR TITLE
🚀 ErikrafT Drop Android 10.0.4 — WebChat, P2P integrity and server failover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update ErikrafT Drop web submodule
+        run: git submodule update --init --remote --depth 1 ErikrafT-Drop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -29,6 +34,9 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+
+      - name: Install Android 16 SDK
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Set up Gradle cache
         uses: gradle/actions/setup-gradle@v4
@@ -68,6 +76,19 @@ jobs:
             echo "Decoded keystore is missing or empty." >&2
             exit 1
           fi
+
+      - name: Validate signing secrets
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          for value in KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+            if [ -z "${!value}" ]; then
+              echo "${value} secret is not configured." >&2
+              exit 1
+            fi
+          done
 
       - name: Build signed mobile release APK and AAB
         env:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ErikrafT Drop is a local file sharing solution which completely works in your br
 
 ### 📱 Features
 - **Server fallback priority**: `https://drop.erikraft.com/` (Primary), `https://drop-fallback.erikraft.com/` (Secondary), `https://dropfallback.erikraft.com/` (Tertiary), `https://pairdrop.net/` (Quaternary / competitor). Custom servers remain supported.
+- **P2P file transfer integrity**: Android-to-Web transfers continue to use the native file picker/WebView file input path without an additional byte-conversion layer. Web-to-Android receiving uses the existing WebRTC chunks and Android bridge, now with serialized writes and an expected-size check before a received file is finalized; incomplete/mismatched files are deleted instead of being presented as valid downloads.
 - **ERIKRAFT-QR Protocol**: Offline animated QR transfer (Send File, Send Text, Receive Animated QR) using Fountain FEC, CRC32, and SHA-256 integrity verification. Works completely offline in Airplane mode without Wi-Fi, Bluetooth, or server connection.
 - **Advanced WebView & WebRTC**: Full WebRTC and WebSocket peer-to-peer file sharing and chat compatible with the official ErikrafT Drop instances and PairDrop.
 - **Tor .onion Network**: Supports accessing .onion addresses through system SOCKS5 proxy / Orbot configuration.
@@ -70,7 +71,7 @@ For a signed release, configure these repository/environment secrets:
 
 The workflow validates that all signing inputs are present, keeps the keystore in the temporary runner directory, removes it after the job, builds both APK and AAB, and verifies the resulting signatures. It also builds against Android 16 (API 36) and refreshes the `ErikrafT-Drop` web submodule from its `master` branch.
 
-> **Current Android app version:** `10.0.3` (version code `20`).
+> **Current Android app version:** `10.0.4` (version code `21`).
 > **Target/Compile SDK:** Android 16 / API 36.
 
 The Android application and the web application use independent version numbers. The web application version is maintained in the `ErikrafT/Drop` repository.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
 ![Forks](https://custom-icon-badges.demolab.com/github/forks/erikraft/Drop-Android?logo=fork&style=social&logoColor=000000)
 ![Watchers](https://custom-icon-badges.demolab.com/github/watchers/erikraft/Drop-Android?logo=eye&style=social&logoColor=000000)
 
-
 <img src="https://biodrop.erikraft.com/images/Logo.png" width="20px" style="display:inline;">｜ErikrafT Drop available on the Web and also as Extensions: [CLICK HERE](https://github.com/erikraft/Drop/)
 
 # ErikrafT Drop™ for Android
 <img align="right" src="app/src/main/res/mipmap-xxxhdpi/ic_launcher.png">
 
-**ErikrafT Drop™ for Android** is an android client for the free and open source local file sharing solution https://drop.erikraft.com/.
+**ErikrafT Drop™ for Android** is an Android client for the free and open source local file sharing solution https://drop.erikraft.com/.
 
 >[!TIP]
 >Do you also sometimes have the problem that you just need to quickly transfer a file from your phone to the PC?
@@ -69,46 +68,18 @@ Your contributions help make the app accessible to users worldwide!
 ### ✍🏻｜Development
 If you want to help with development, this would be more than welcome! I am very glad about every pull request. Just fork the repo and start coding. However, if you plan to implement larger changes, please tell us in the [issue tracker](https://github.com/erikraft/Drop-Android/issues) before hacking on your great new feature.
 
-### 🤖｜Play Store automation
-This repository ships with a GitHub Actions workflow (`Publish to Google Play`) that automatically builds a release bundle and uploads it to the Google Play Store whenever changes are pushed to the `main` branch. To enable the workflow:
+### 🤖｜Release and Play Store automation
+This repository includes a manual GitHub Actions release pipeline at `.github/workflows/release.yml` that builds and signs the mobile APK and AAB. It can also run automatically for version tags (`v*`).
 
-1. Create a Google Cloud service account with access to the Google Play Developer API and download its JSON key.
-2. Base64 encode the JSON key file and store it as the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret in the repository settings.
-3. Adjust the default track (`production`) or release status (`completed`) by editing the environment variables in `.github/workflows/play-store-publish.yml` if needed.
+For a signed release, configure these repository/environment secrets:
 
-The workflow relies on the Gradle Play Publisher plugin and will run `./gradlew publishReleaseBundle` to upload the generated app bundle to the selected track.
+- `KEYSTORE_FILE`: Base64-encoded Android keystore file.
+- `KEY_ALIAS`: Alias of the signing key.
+- `KEYSTORE_PASSWORD`: Keystore password.
+- `KEY_PASSWORD`: Signing key password.
 
-### 🤖｜Self-hosted F-Droid automation
-The project also includes a workflow (`Publish to self-hosted F-Droid repo`) that prepares an F-Droid compatible repository whenever a GitHub release is published (you can also trigger it manually through the *Actions* tab). The workflow builds the signed APK, updates the metadata under `fdroid/`, generates the F-Droid index using [`fdroidserver`](https://gitlab.com/fdroid/fdroidserver), and publishes the result to the `fdroid` branch which can be served through GitHub Pages or any static hosting provider.
+The workflow validates that all signing inputs are present, keeps the keystore in the temporary runner directory, removes it after the job, builds both APK and AAB, and verifies the resulting signatures. It also builds against Android 16 (API 36) and refreshes the `ErikrafT-Drop` web submodule from its `master` branch so the Android WebView client stays aligned with the current web application.
 
-To enable the workflow:
+> **Current Android app version:** `10.0.1` (version code `18`).
 
-1. Base64-encode the keystore that is used to sign production releases and save it as the `FDROID_KEYSTORE_BASE64` secret.
-2. Add the passwords and alias of that keystore as repository secrets: `FDROID_KEYSTORE_PASSWORD`, `FDROID_KEY_PASSWORD`, and `FDROID_KEY_ALIAS`.
-3. (Optional) Provide custom repository metadata by defining the secrets `FDROID_REPO_URL`, `FDROID_REPO_NAME`, `FDROID_REPO_DESCRIPTION`, and `FDROID_REPO_ADDRESS`. Default values are used when they are not supplied.
-4. Enable GitHub Pages for the repository (or configure another static host) to serve the contents of the `fdroid` branch so that F-Droid clients can consume the index.
-
-After the first successful run you will have a fully automated, self-hosted F-Droid catalogue that mirrors the signed releases from this repository.
-
-## ⚙️｜Other software
-### ✨｜Related software
-- ErikrafT Drop Extension for desktop platforms: [ErikrafT Drop Extension](https://github.com/erikraft/Drop/tree/master/Extensions)
-- ErikrafT Drop Discord integration: [ErikrafT Drop Discord Bot and Activity](https://github.com/erikraft/Drop/tree/master/Discord)
-- ErikrafT Drop Apple Shortcut integration: [ErikrafT Drop Apple Shortcut](https://github.com/erikraft/Drop/tree/master/Shortcut)
-- And for sure, ErikrafT Drop directly inside the browser – just use it everywhere: https://drop.erikraft.com/
-
-### ⁉️｜Alternatives
-- Apple Airdrop (Mac and IOS only, plus an unofficial [open source implementation](https://github.com/seemoo-lab/opendrop) for Linux) 
-- Google Nearby Share (Android, Chrome OS and [Windows](https://www.android.com/better-together/nearby-share-app/), plus an unofficial [macOS client](https://github.com/grishka/NearDrop))
-- Windows Nearby Sharing (Windows only, there is a [FLOSS implementation](https://github.com/ShortDevelopment/Nearby-Sharing-Windows) for android)
-- Link to Windows (Your Android phone will be mounted as storage directly in your Windows file explorer, [read more](https://blogs.windows.com/windows-insider/2024/07/25/ability-to-access-your-android-phone-in-file-explorer-begins-rolling-out-to-windows-insiders/))
-
-🙏 Thank you everyone's support :)
-
-<a href="https://www.star-history.com/#erikraft/Drop-Android&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=erikraft/Drop-Android&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=erikraft/Drop-Android&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=erikraft/Drop-Android&type=Date" />
- </picture>
-</a>
+The Android application and the web application use independent version numbers. The web application version is maintained in the `ErikrafT/Drop` repository.

--- a/README.md
+++ b/README.md
@@ -29,25 +29,15 @@
 ErikrafT Drop is a local file sharing solution which completely works in your browser. A bit like Apple's Airdrop, but not only for Apple devices. Windows, Linux, Android, IPhone, Mac - no problem at all!
 
 ### 📱 Features
+- **Server fallback priority**: `https://drop.erikraft.com/` (Primary), `https://drop-fallback.erikraft.com/` (Secondary), `https://dropfallback.erikraft.com/` (Tertiary), `https://pairdrop.net/` (Quaternary / competitor). Custom servers remain supported.
 - **ERIKRAFT-QR Protocol**: Offline animated QR transfer (Send File, Send Text, Receive Animated QR) using Fountain FEC, CRC32, and SHA-256 integrity verification. Works completely offline in Airplane mode without Wi-Fi, Bluetooth, or server connection.
-- **Advanced WebView & WebRTC**: Full WebRTC and WebSocket peer-to-peer file sharing and chat compatible with https://drop.erikraft.com and PairDrop (https://pairdrop.net).
-- **Tor .onion Network**: Supports accessing .onion addresses through system SOCKS5 proxy / Orbot configuration (plain HTTP on Android System WebView does not bypass system proxy settings to preserve TLS/SSL security).
+- **Advanced WebView & WebRTC**: Full WebRTC and WebSocket peer-to-peer file sharing and chat compatible with the official ErikrafT Drop instances and PairDrop.
+- **Tor .onion Network**: Supports accessing .onion addresses through system SOCKS5 proxy / Orbot configuration.
 
 However, even if it theoretically would fully work in your browser and you don't have to install anything, you will love this app if you want to use ErikrafT Drop more often in your daily life. Thanks to perfect integration into the Android operating system, files are sent even faster. Directly from within other apps you can select ErikrafT Drop to share with. Thanks to its radical simplicity, "ErikrafT Drop™ for Android" makes the everyday life of hundreds of users easier. As an open source project we don't have any commercial interests but want to make the world a little bit better. Join and convince yourself!
 
 ## ⏬｜Where can I download the app?
 **ErikrafT Drop™ for Android** is available on [Google Play](https://play.google.com/store/apps/details?id=com.erikraft.drop) and [F-Droid](https://f-droid.org/en/packages/com.erikraft.drop/).
-<div align='center' style='display: inline_block; gap: 10px;'><br>
-  <a href='https://play.google.com/store/apps/details?id=com.erikraft.drop' target='_blank'>
-    <img alt='Get it on Google Play' height='80' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'>
-  </a>
-  <a href='https://f-droid.org/en/packages/com.erikraft.drop/' target='_blank'>
-    <img alt='Get it on F-Droid' height='80' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png'>
-  </a>
-  <a href="https://apkpure.com/p/com.erikraft.drop" target="_blank">
-    <img alt="Get it on APKPure" style="height: 60px;" src="https://raw.githubusercontent.com/erikraft/Drop/master/public/images/badges/Get_it_on_APKPure_English.png">
-  </a>
-</div>
 
 ## 📲｜Screenshots
 <img src="app/src/main/res/drawable/tv_banner.png" width="43.3%"></img> <img src=".screenshot/ErikrafT-Drop_Screenshots_1.png" width="10%"></img> <img src=".screenshot/ErikrafT-Drop_Screenshots_2.png" width="10%"></img> <img src=".screenshot/ErikrafT-Drop_Screenshots_3.png" width="10%"></img> <img src=".screenshot/ErikrafT-Drop_Screenshots_4.png" width="10%"></img> <img src=".screenshot/erikraftdrop_screenshot_mobile.gif" width="10%"></img>
@@ -78,8 +68,9 @@ For a signed release, configure these repository/environment secrets:
 - `KEYSTORE_PASSWORD`: Keystore password.
 - `KEY_PASSWORD`: Signing key password.
 
-The workflow validates that all signing inputs are present, keeps the keystore in the temporary runner directory, removes it after the job, builds both APK and AAB, and verifies the resulting signatures. It also builds against Android 16 (API 36) and refreshes the `ErikrafT-Drop` web submodule from its `master` branch so the Android WebView client stays aligned with the current web application.
+The workflow validates that all signing inputs are present, keeps the keystore in the temporary runner directory, removes it after the job, builds both APK and AAB, and verifies the resulting signatures. It also builds against Android 16 (API 36) and refreshes the `ErikrafT-Drop` web submodule from its `master` branch.
 
-> **Current Android app version:** `10.0.2` (version code `19`).
+> **Current Android app version:** `10.0.3` (version code `20`).
+> **Target/Compile SDK:** Android 16 / API 36.
 
 The Android application and the web application use independent version numbers. The web application version is maintained in the `ErikrafT/Drop` repository.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ For a signed release, configure these repository/environment secrets:
 
 The workflow validates that all signing inputs are present, keeps the keystore in the temporary runner directory, removes it after the job, builds both APK and AAB, and verifies the resulting signatures. It also builds against Android 16 (API 36) and refreshes the `ErikrafT-Drop` web submodule from its `master` branch so the Android WebView client stays aligned with the current web application.
 
-> **Current Android app version:** `10.0.1` (version code `18`).
+> **Current Android app version:** `10.0.2` (version code `19`).
 
 The Android application and the web application use independent version numbers. The web application version is maintained in the `ErikrafT/Drop` repository.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
-        versionCode 20
-        versionName "10.0.3"
+        versionCode 21
+        versionName "10.0.4"
         applicationVariants.all { variant ->
             variant.outputs.all {
                 outputFileName = "Drop-Android.apk"
@@ -61,13 +61,11 @@ android {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
 
-    // use Java 8 to make use of lambda-expressions, etc.
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    // Load keystore properties from Gradle properties, optional keystore.properties, or environment variables.
     def keystorePropertiesFile = rootProject.file('keystore.properties')
     def keystoreProperties = new Properties()
     if (keystorePropertiesFile.exists()) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
-        versionCode 19
-        versionName "10.0.2"
+        versionCode 20
+        versionName "10.0.3"
         applicationVariants.all { variant ->
             variant.outputs.all {
                 outputFileName = "Drop-Android.apk"
@@ -123,7 +123,6 @@ android {
 
         buildTypes {
             release {
-                // preserve existing release configuration
                 minifyEnabled true
                 proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
                 signingConfig signingConfigs.release
@@ -132,7 +131,6 @@ android {
     }
 
     lintOptions {
-        // Ignore warnings about missing translations and extra translations
         disable 'MissingTranslation', 'ExtraTranslation'
     }
 }
@@ -154,15 +152,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-
     implementation 'com.anggrayudi:storage:1.5.6'
     implementation 'com.google.zxing:core:3.5.3'
 }
-
-/*
- * own checkstyle configuration
- * Android plugin doesn't interoperate with the Checkstyle plugin
- */
 
 tasks.register('checkstyle', Checkstyle) {
     configFile file("${project.rootDir}/checkstyle.xml")
@@ -170,7 +162,6 @@ tasks.register('checkstyle', Checkstyle) {
     source '../test/java'
     source '../androidTest/java'
     include '**/*.java'
-
     classpath = files()
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,15 +13,15 @@ aboutLibraries {
 
 android {
     namespace 'com.erikraft.drop'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.erikraft.drop"
         minSdkVersion 21
-        targetSdkVersion 35
+        targetSdkVersion 36
 
-        versionCode 17
-        versionName "10.0.0"
+        versionCode 18
+        versionName "10.0.1"
         applicationVariants.all { variant ->
             variant.outputs.all {
                 outputFileName = "Drop-Android.apk"
@@ -61,7 +61,7 @@ android {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
 
-    // use Java 8 to make use of lamda-expressions, etc.
+    // use Java 8 to make use of lambda-expressions, etc.
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -134,12 +134,6 @@ android {
     lintOptions {
         // Ignore warnings about missing translations and extra translations
         disable 'MissingTranslation', 'ExtraTranslation'
-    }
-
-    // use Java 8 to make use of lamda-expressions, etc.
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
-        versionCode 18
-        versionName "10.0.1"
+        versionCode 19
+        versionName "10.0.2"
         applicationVariants.all { variant ->
             variant.outputs.all {
                 outputFileName = "Drop-Android.apk"

--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -54,7 +54,6 @@ try {
     console.error(e);
 }
 
-
 //retarget donation button (play guidelines)
 try {
     document.querySelector('.icon-button[href*="paypal"]').href = 'https://ko-fi.com/erikraft/';
@@ -140,7 +139,6 @@ try {
 
 //detect dialogs
 try {
-    // Only override dialog methods when an Android bridge exists. Preserve originals if present.
     const _androidBridge = (typeof ErikrafTdropAndroid !== 'undefined') ? ErikrafTdropAndroid : (typeof SnapdropAndroid !== 'undefined' ? SnapdropAndroid : null);
     if (_androidBridge) {
         if (!Dialog.prototype._shw) Dialog.prototype._shw = Dialog.prototype.show;
@@ -174,7 +172,6 @@ try {
     if (!localizationBuiltIn) {
         let localizeDisplayName = function (str) {
             const displayNameNode = document.getElementById('displayName');
-            // don't change it e.g. for pairdrop.net
             if (displayNameNode.textContent.substring(0, 17) === "You are known as ") {
                 displayNameNode.textContent = SnapdropAndroid.getYouAreKnownAsTranslationString(str);
             }
@@ -196,31 +193,94 @@ window.addEventListener('file-received', e => {
 }, false);
 
 window.addEventListener('files-received', e => {
-    // vibrates after receiving all files (supported only on PairDrop)
     SnapdropAndroid.vibrate();
 }, false);
 
 window.addEventListener('files-sent', e => {
-    // vibrates after sending all files (supported only on PairDrop)
     SnapdropAndroid.vibrate();
 }, false);
 
 window.addEventListener('share-mode-changed', e => {
-    // remove upload intent on canceling share mode (supported only on PairDrop)
     if (!e.detail.active) {
         SnapdropAndroid.resetUploadIntent();
     }
 }, false);
 
+// Android WebView does not reliably handle blob:/data: downloads by itself.
+// Route download anchors through the native bridge so WebChat images, text files,
+// and other client-generated downloads can be saved to the Android Downloads location.
+try {
+    const androidDownloadBridge = (typeof ErikrafTdropAndroid !== 'undefined')
+        ? ErikrafTdropAndroid
+        : (typeof SnapdropAndroid !== 'undefined' ? SnapdropAndroid : null);
+
+    if (androidDownloadBridge && !window.__erikraftAndroidDownloadBridgeInstalled) {
+        window.__erikraftAndroidDownloadBridgeInstalled = true;
+
+        const downloadAnchor = async (anchor, event) => {
+            const href = anchor && (anchor.href || anchor.getAttribute('href'));
+            if (!anchor || !anchor.hasAttribute('download') || !href) return false;
+            if (!href.startsWith('blob:') && !href.startsWith('data:') && !href.startsWith('http:') && !href.startsWith('https:')) return false;
+
+            if (event) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+
+            try {
+                const response = await fetch(href, { credentials: 'include' });
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const blob = await response.blob();
+                const reader = new FileReader();
+                reader.onloadend = () => {
+                    const result = String(reader.result || '');
+                    const separator = result.indexOf(',');
+                    const base64 = separator >= 0 ? result.substring(separator + 1) : result;
+                    androidDownloadBridge.downloadBase64File(
+                        anchor.getAttribute('download') || 'download',
+                        blob.type || 'application/octet-stream',
+                        base64
+                    );
+                };
+                reader.readAsDataURL(blob);
+                return true;
+            } catch (error) {
+                console.error('Android WebView download bridge failed', error);
+                return false;
+            }
+        };
+
+        document.addEventListener('click', event => {
+            const target = event.target instanceof Element ? event.target.closest('a[download]') : null;
+            if (target) {
+                const href = target.href || target.getAttribute('href') || '';
+                if (href.startsWith('blob:') || href.startsWith('data:') || href.startsWith('http:') || href.startsWith('https:')) {
+                    downloadAnchor(target, event);
+                }
+            }
+        }, true);
+
+        const originalAnchorClick = HTMLAnchorElement.prototype.click;
+        HTMLAnchorElement.prototype.click = function () {
+            const href = this.href || this.getAttribute('href') || '';
+            if (this.hasAttribute('download') && (href.startsWith('blob:') || href.startsWith('data:') || href.startsWith('http:') || href.startsWith('https:'))) {
+                downloadAnchor(this, null);
+                return;
+            }
+            return originalAnchorClick.apply(this, arguments);
+        };
+    }
+} catch (e) {
+    console.error('Unable to install Android WebView download bridge', e);
+}
+
 //hide unnecessary web toolbar buttons
 try {
-    // snapdrop.net - theme
     document.querySelector('#theme').style.display = "none";
 } catch (e) {
     console.error(e);
 }
 try {
-    // pairdrop.net - theme
     document.querySelector('#theme-wrapper').style.display = "none";
     localStorage.removeItem('theme');
     document.body.classList.remove('dark-theme');
@@ -229,19 +289,16 @@ try {
     console.error(e);
 }
 try {
-    // remove pairdrop language selector
     document.getElementById('language-selector').style.display = "none";
 } catch (e) {
     console.error(e);
 }
 try {
-    // remove pairdrop overflow menu
     document.getElementById('expand').style.display = "none";
 } catch (e) {
     console.error(e);
 }
 try {
-    // other items
     document.querySelector('.icon-button[href="#about"]').style.display = "none";
     document.querySelector('.icon-button[href="#"]').style.display = "none";
 } catch (e) {

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -108,14 +108,20 @@ public class JavaScriptInterface {
 
         try {
             final byte[] bytes = Base64.decode(base64Data, Base64.DEFAULT);
-            final FileWrapper wrapper = createFileWrapper(name, mime);
-            if (wrapper == null) {
-                throw new IOException("Unable to create download target");
+            final DocumentFile saveLocation = MainActivity.getSaveLocation();
+            if (saveLocation == null) {
+                throw new IOException("Unable to access Android Downloads location");
             }
 
-            final OutputStream outputStream = UriUtils.openOutputStream(wrapper.getUri(), context.getApplicationContext());
+            final DocumentFile target = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(),
+                    name, mime);
+            if (target == null) {
+                throw new IOException("Unable to create Android download file");
+            }
+
+            final OutputStream outputStream = UriUtils.openOutputStream(target.getUri(), context.getApplicationContext());
             if (outputStream == null) {
-                throw new IOException("Unable to open download target");
+                throw new IOException("Unable to open Android download file");
             }
 
             try {
@@ -125,12 +131,9 @@ public class JavaScriptInterface {
                 IOUtils.closeStreamQuietly(outputStream);
             }
 
-            final FileHeader header = new FileHeader(name, mime, String.valueOf(bytes.length), wrapper);
             Log.i("DropAndroidJS", "Web download saved: " + name + " (" + bytes.length + " bytes)");
-            context.runOnUiThread(() -> {
-                context.downloadFilesList.add(header);
-                context.copyTempToDownloads(header);
-            });
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
+                    "Baixado: " + name, android.widget.Toast.LENGTH_LONG).show());
         } catch (Exception e) {
             Log.e("DropAndroidJS", "Web download failed: " + name, e);
             context.runOnUiThread(() -> android.widget.Toast.makeText(context,

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Environment;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.text.TextUtils;
@@ -24,7 +23,6 @@ import com.erikraft.drop.utils.ClipboardUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -35,18 +35,27 @@ public class JavaScriptInterface {
     private FileHeader fileHeader;
     private java.security.MessageDigest messageDigest;
     private long totalBytesReceived = 0;
+    private long expectedBytes = -1;
+    private boolean transferActive = false;
 
     public JavaScriptInterface(final MainActivity context) {
         this.context = context;
     }
 
     @JavascriptInterface
-    public void newFile(final String fileName, final String mimeType, final String fileSize) throws IOException {
+    public synchronized void newFile(final String fileName, final String mimeType, final String fileSize) throws IOException {
         Log.i("DropAndroidJS", "Transfer Start: Receiving file. fileName=" + fileName + ", mimeType=" + mimeType + ", fileSize=" + fileSize);
         String finalMime = mimeType;
         if (mimeType.startsWith("base64:")) {
             finalMime = mimeType.substring(7);
         }
+
+        IOUtils.closeStreamQuietly(fileOutputStream);
+        fileOutputStream = null;
+        fileHeader = null;
+        totalBytesReceived = 0;
+        expectedBytes = parseExpectedBytes(fileSize);
+        transferActive = false;
 
         final FileWrapper fileWrapper = createFileWrapper(fileName, finalMime);
         if (fileWrapper == null) {
@@ -59,11 +68,22 @@ public class JavaScriptInterface {
             throw new IOException("Cannot write target file");
         }
         fileHeader = new FileHeader(fileName, finalMime, fileSize, fileWrapper);
-        totalBytesReceived = 0;
         try {
             messageDigest = java.security.MessageDigest.getInstance("SHA-256");
         } catch (java.security.NoSuchAlgorithmException e) {
             messageDigest = null;
+        }
+    }
+
+    private long parseExpectedBytes(final String fileSize) {
+        if (TextUtils.isEmpty(fileSize)) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(fileSize.trim());
+        } catch (NumberFormatException e) {
+            Log.w("DropAndroidJS", "Unable to parse expected file size: " + fileSize);
+            return -1;
         }
     }
 
@@ -91,11 +111,6 @@ public class JavaScriptInterface {
         }
     }
 
-    /**
-     * Handles downloads generated entirely by the WebChat UI, including blob: and data:
-     * URLs. WebView's normal DownloadListener cannot consume those URLs directly, so the
-     * page converts the payload to Base64 and calls this bridge method.
-     */
     @JavascriptInterface
     public void downloadBase64File(final String requestedName, final String requestedMime, final String base64Data) {
         if (base64Data == null || base64Data.isEmpty()) {
@@ -150,19 +165,24 @@ public class JavaScriptInterface {
         return name;
     }
 
+    /**
+     * Writes each binary WebRTC chunk exactly once. The synchronized bridge prevents
+     * concurrent JavaScript-interface calls from interleaving writes to the same stream.
+     */
     @JavascriptInterface
-    public void onBytes(final String dec) throws IOException {
-        if (fileOutputStream == null) {
-            Log.e("DropAndroidJS", "Transfer Failure: fileOutputStream is null during onBytes");
+    public synchronized void onBytes(final String dec) throws IOException {
+        if (fileOutputStream == null || fileHeader == null || !transferActive && totalBytesReceived > 0) {
+            Log.e("DropAndroidJS", "Transfer Failure: no active file stream during onBytes");
             return;
         }
         try {
-            byte[] bytes = Base64.decode(dec, Base64.NO_WRAP);
+            final byte[] bytes = Base64.decode(dec, Base64.NO_WRAP);
             fileOutputStream.write(bytes);
             if (messageDigest != null) {
                 messageDigest.update(bytes);
             }
             totalBytesReceived += bytes.length;
+            transferActive = true;
         } catch (Exception e) {
             Log.e("DropAndroidJS", "Transfer Failure: Exception during write of file bytes", e);
             throw new IOException("Failed to process bytes", e);
@@ -170,17 +190,26 @@ public class JavaScriptInterface {
     }
 
     @JavascriptInterface
-    public void saveDownloadFileName(final String name, final String size) throws IOException {
+    public synchronized void saveDownloadFileName(final String name, final String size) throws IOException {
+        if (fileOutputStream == null || fileHeader == null) {
+            Log.e("DropAndroidJS", "Transfer Failure: completion received without an active file");
+            return;
+        }
+
+        final long completedExpectedBytes = parseExpectedBytes(size);
+        final long expected = completedExpectedBytes >= 0 ? completedExpectedBytes : expectedBytes;
+        final boolean sizeMatches = expected < 0 || expected == totalBytesReceived;
+
         String sha256Hex = "";
         if (messageDigest != null) {
-            byte[] hash = messageDigest.digest();
-            StringBuilder sb = new StringBuilder();
+            final byte[] hash = messageDigest.digest();
+            final StringBuilder sb = new StringBuilder();
             for (byte b : hash) {
                 sb.append(String.format("%02x", b));
             }
             sha256Hex = sb.toString();
         }
-        Log.i("DropAndroidJS", "Transfer Complete: Saved file " + name + " (Expected Size: " + size + ", Bytes Received: " + totalBytesReceived + ", SHA-256: " + sha256Hex + ", Integrity: OK)");
+
         try {
             fileOutputStream.flush();
             fileOutputStream.close();
@@ -188,10 +217,33 @@ public class JavaScriptInterface {
             Log.e("DropAndroidJS", "Transfer Failure: Exception during flush/close of file output stream", e);
             throw e;
         } finally {
+            fileOutputStream = null;
             messageDigest = null;
+            transferActive = false;
         }
 
+        if (!sizeMatches) {
+            Log.e("DropAndroidJS", "Transfer Failure: Size mismatch for " + name
+                    + " (Expected: " + expected + ", Received: " + totalBytesReceived
+                    + ", SHA-256: " + sha256Hex + ")");
+            if (fileHeader.file.delete()) {
+                Log.w("DropAndroidJS", "Corrupted/incomplete file deleted: " + name);
+            }
+            fileHeader = null;
+            expectedBytes = -1;
+            totalBytesReceived = 0;
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
+                    "Transferência incompleta: " + name, android.widget.Toast.LENGTH_LONG).show());
+            return;
+        }
+
+        Log.i("DropAndroidJS", "Transfer Complete: Saved file " + name
+                + " (Expected Size: " + expected + ", Bytes Received: " + totalBytesReceived
+                + ", SHA-256: " + sha256Hex + ", Integrity: Size OK)");
         context.downloadFilesList.add(fileHeader);
+        fileHeader = null;
+        expectedBytes = -1;
+        totalBytesReceived = 0;
     }
 
     public static String getSendTextDialogWithPreInsertedString(final String text) {
@@ -242,16 +294,21 @@ public class JavaScriptInterface {
     }
 
     @JavascriptInterface
-    public void ignoreClickedListener() {
+    public synchronized void ignoreClickedListener() {
         Log.i("DropAndroidJS", "Transfer Canceled: Ignore clicked by user.");
         IOUtils.closeStreamQuietly(fileOutputStream);
+        fileOutputStream = null;
         messageDigest = null;
+        transferActive = false;
+        expectedBytes = -1;
+        totalBytesReceived = 0;
         if (fileHeader != null && fileHeader.file.delete()) {
             Log.d("ignoreClickListener", "File was deleted from SAF database");
         } else {
             Log.d("ignoreClickListener",
                     "Ignore was clicked, however we haven't recognized that a file was downloaded at all");
         }
+        fileHeader = null;
     }
 
     @JavascriptInterface

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.text.TextUtils;
@@ -23,6 +24,7 @@ import com.erikraft.drop.utils.ClipboardUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -67,17 +69,8 @@ public class JavaScriptInterface {
         }
     }
 
-    private FileWrapper createFileWrapper(final String fileName, final String mimeType) throws IOException { // ...
-                                                                                                             // existing
-                                                                                                             // code ...
+    private FileWrapper createFileWrapper(final String fileName, final String mimeType) throws IOException {
         if (Build.VERSION.SDK_INT > 28) {
-            /*
-             * Make file transfer faster 2x on scoped storage by writing to media store
-             * database directly,
-             * instead of writing to temporary file first. It could save storage lifetime
-             * because
-             * the file is written once only.
-             */
             final DocumentFile saveLocation = MainActivity.getSaveLocation();
             if (saveLocation != null) {
                 final DocumentFile file = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(),
@@ -90,11 +83,6 @@ public class JavaScriptInterface {
             return DocumentFileCompat.createDownloadWithMediaStoreFallback(context.getApplicationContext(),
                     description);
         } else {
-            /*
-             * Prior to scoped storage restriction, SimpleStorage will use File#renameTo(),
-             * so no need to worry
-             * about the storage's lifetime.
-             */
             final String[] nameSplit = fileName.split("\\.");
             while (nameSplit[0].length() < 3) {
                 nameSplit[0] += nameSplit[0];
@@ -103,6 +91,62 @@ public class JavaScriptInterface {
                     File.createTempFile(nameSplit[0], "." + nameSplit[nameSplit.length - 1], context.getCacheDir()));
             return new FileWrapper.Document(file);
         }
+    }
+
+    /**
+     * Handles downloads generated entirely by the WebChat UI, including blob: and data:
+     * URLs. WebView's normal DownloadListener cannot consume those URLs directly, so the
+     * page converts the payload to Base64 and calls this bridge method.
+     */
+    @JavascriptInterface
+    public void downloadBase64File(final String requestedName, final String requestedMime, final String base64Data) {
+        if (base64Data == null || base64Data.isEmpty()) {
+            Log.w("DropAndroidJS", "Web download ignored: empty payload");
+            return;
+        }
+
+        final String name = sanitizeDownloadName(requestedName);
+        final String mime = TextUtils.isEmpty(requestedMime) ? "application/octet-stream" : requestedMime;
+
+        try {
+            final byte[] bytes = Base64.decode(base64Data, Base64.DEFAULT);
+            final FileWrapper wrapper = createFileWrapper(name, mime);
+            if (wrapper == null) {
+                throw new IOException("Unable to create download target");
+            }
+
+            final OutputStream outputStream = UriUtils.openOutputStream(wrapper.getUri(), context.getApplicationContext());
+            if (outputStream == null) {
+                throw new IOException("Unable to open download target");
+            }
+
+            try {
+                outputStream.write(bytes);
+                outputStream.flush();
+            } finally {
+                IOUtils.closeStreamQuietly(outputStream);
+            }
+
+            final FileHeader header = new FileHeader(name, mime, String.valueOf(bytes.length), wrapper);
+            Log.i("DropAndroidJS", "Web download saved: " + name + " (" + bytes.length + " bytes)");
+            context.runOnUiThread(() -> {
+                context.downloadFilesList.add(header);
+                context.copyTempToDownloads(header);
+            });
+        } catch (Exception e) {
+            Log.e("DropAndroidJS", "Web download failed: " + name, e);
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
+                    "Falha ao baixar " + name, android.widget.Toast.LENGTH_LONG).show());
+        }
+    }
+
+    private String sanitizeDownloadName(final String requestedName) {
+        String name = TextUtils.isEmpty(requestedName) ? "download" : requestedName;
+        name = name.replace('\\', '_').replace('/', '_').replace('\n', '_').replace('\r', '_');
+        if (name.equals(".") || name.equals("..")) {
+            return "download";
+        }
+        return name;
     }
 
     @JavascriptInterface
@@ -151,7 +195,6 @@ public class JavaScriptInterface {
 
     public static String getSendTextDialogWithPreInsertedString(final String text) {
         return "javascript: " +
-        // snapdrop
                 "try {" +
                 "    document.getElementById(\"textInput\").innerHTML=\""
                 + TextUtils.htmlEncode(text).replaceAll("\\n", "<br />") + "\";" +
@@ -159,7 +202,6 @@ public class JavaScriptInterface {
                 "} catch (e) {" +
                 "    console.error(\"Error setting pre-inserted text (snapdrop based): \" + e);" +
                 "}" +
-                // PairDrop
                 "Events.fire('activate-share-mode', {text: SnapdropAndroid.getTextFromUploadIntent()});";
     }
 
@@ -218,8 +260,7 @@ public class JavaScriptInterface {
             context.transfer.set(true);
         } else {
             context.transfer.set(false);
-            context.forceRefresh = false; // reset forceRefresh after transfer finished so pullToRefresh doesn't
-                                          // unexpectedly force refreshes by "first time"
+            context.forceRefresh = false;
         }
     }
 
@@ -290,8 +331,7 @@ public class JavaScriptInterface {
             final StringBuilder text = new StringBuilder("javascript:");
             String currentLine;
             while ((currentLine = reader.readLine()) != null) {
-                if (!currentLine.trim().startsWith("//")) { // should support inline comments as well, however keep in
-                                                            // mind that '//' might occur inside a string as well
+                if (!currentLine.trim().startsWith("//")) {
                     text.append(currentLine);
                 }
             }

--- a/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
+++ b/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
@@ -148,7 +148,7 @@ public class OnboardingFragment2 extends Fragment {
                 return;
             }
 
-            if (url.startsWith("!!")) { // hidden feature to force a different url
+            if (url.startsWith("!!")) {
                 newServer(url.substring("!!".length()));
             } else if (url.startsWith("http")) {
                 NetworkUtils.checkInstance(this, url, result -> {
@@ -157,9 +157,6 @@ public class OnboardingFragment2 extends Fragment {
                     }
                 });
             } else {
-
-                // do some magic in case user forgot to specify the protocol
-
                 String mightBeHttpsUrl = "https://" + url;
                 NetworkUtils.checkInstance(this, mightBeHttpsUrl, resultHttps -> {
                     if (resultHttps) {
@@ -190,12 +187,22 @@ public class OnboardingFragment2 extends Fragment {
     private void reloadServerList() {
         final Set<String> serverUrls = pref.getStringSet(getString(R.string.pref_custom_servers), new HashSet<>());
 
+        // Keep official ErikrafT instances in a deterministic priority order.
+        // PairDrop remains available only as the fourth/final fallback.
         final List<ServerItem> servers = new ArrayList<>();
-        servers.add(new ServerItem("https://drop.erikraft.com/", getString(R.string.onboarding_server_pairdrop_summary), null));
-        servers.add(new ServerItem("https://pairdrop.net", getString(R.string.onboarding_server_snapdrop_summary_server_warning), null));
+        servers.add(new ServerItem("https://drop.erikraft.com/", getString(R.string.onboarding_server_primary_summary), null));
+        servers.add(new ServerItem("https://drop-fallback.erikraft.com/", getString(R.string.onboarding_server_secondary_summary), null));
+        servers.add(new ServerItem("https://dropfallback.erikraft.com/", getString(R.string.onboarding_server_tertiary_summary), null));
+        servers.add(new ServerItem("https://pairdrop.net/", getString(R.string.onboarding_server_quaternary_summary), null));
 
         for (String url : serverUrls) {
-            servers.add(new ServerItem(url, null, null));
+            if (!url.equals("https://drop.erikraft.com/")
+                    && !url.equals("https://drop-fallback.erikraft.com/")
+                    && !url.equals("https://dropfallback.erikraft.com/")
+                    && !url.equals("https://pairdrop.net/")
+                    && !url.equals("https://pairdrop.net")) {
+                servers.add(new ServerItem(url, null, null));
+            }
         }
 
         binding.listview.setAdapter(new ServerItemCardAdapter(servers));

--- a/app/src/main/java/com/erikraft/drop/qr/QRTransferActivity.java
+++ b/app/src/main/java/com/erikraft/drop/qr/QRTransferActivity.java
@@ -1,13 +1,17 @@
 package com.erikraft.drop.qr;
 
 import android.Manifest;
+import android.content.ContentValues;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.hardware.Camera;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.MediaStore;
 import android.util.Base64;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -37,13 +41,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @SuppressWarnings("deprecation")
 public class QRTransferActivity extends AppCompatActivity implements SurfaceHolder.Callback {
 
-    public static final String EXTRA_MODE = "mode"; // "send_file", "send_text", "receive"
+    public static final String EXTRA_MODE = "mode";
     public static final String EXTRA_TEXT = "text";
     public static final String EXTRA_URI = "uri";
     private static final int PERMISSION_REQUEST_CAMERA = 101;
@@ -62,13 +67,11 @@ public class QRTransferActivity extends AppCompatActivity implements SurfaceHold
     private boolean isPaused = false;
     private boolean isCancelled = false;
 
-    // Send variables
     private byte[][] sendChunks;
     private ErikrafTQRProtocol.Frame baseFrame;
     private int currentChunkIndex = 0;
     private Runnable animationRunnable;
 
-    // Receive variables
     private Camera camera;
     private SurfaceHolder surfaceHolder;
     private QRDecoder qrDecoder = new QRDecoder();
@@ -181,7 +184,7 @@ public class QRTransferActivity extends AppCompatActivity implements SurfaceHold
                         Bitmap qrBitmap = QREncoder.generateQRCode(encodedStr, 400, 400);
                         qrImageView.setImageBitmap(qrBitmap);
                     } catch (Exception e) {
-                        // ignore
+                        // ignore rendering errors and continue the animation
                     }
 
                     currentChunkIndex = (currentChunkIndex + 1) % sendChunks.length;
@@ -286,7 +289,7 @@ public class QRTransferActivity extends AppCompatActivity implements SurfaceHold
         if ("text".equals(result.type)) {
             String text = new String(result.finalData, StandardCharsets.UTF_8);
             ClipboardUtils.copy(this, text);
-            Toast.makeText(this, "Texto recebido e copiado para a área de transferência!", Toast.LENGTH_LONG).show();
+            saveReceivedTextFile(result.name, result.finalData);
         } else {
             try {
                 File file = new File(getExternalFilesDir(null), result.name != null ? result.name : "received_file");
@@ -297,6 +300,59 @@ public class QRTransferActivity extends AppCompatActivity implements SurfaceHold
             } catch (Exception e) {
                 Toast.makeText(this, "Falha ao salvar arquivo recebido", Toast.LENGTH_SHORT).show();
             }
+        }
+    }
+
+    private void saveReceivedTextFile(String requestedName, byte[] data) {
+        String name = requestedName;
+        if (name == null || name.trim().isEmpty()) {
+            name = "received_text.txt";
+        }
+        if (!name.toLowerCase().endsWith(".txt")) {
+            name += ".txt";
+        }
+        name = name.replace('/', '_').replace('\\', '_');
+
+        try {
+            Uri uri;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ContentValues values = new ContentValues();
+                values.put(MediaStore.Downloads.DISPLAY_NAME, name);
+                values.put(MediaStore.Downloads.MIME_TYPE, "text/plain");
+                values.put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
+                values.put(MediaStore.Downloads.IS_PENDING, 1);
+
+                uri = getContentResolver().insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
+                if (uri == null) throw new IllegalStateException("MediaStore insert failed");
+
+                try (OutputStream outputStream = getContentResolver().openOutputStream(uri)) {
+                    if (outputStream == null) throw new IllegalStateException("Unable to open download");
+                    outputStream.write(data);
+                }
+
+                values.clear();
+                values.put(MediaStore.Downloads.IS_PENDING, 0);
+                getContentResolver().update(uri, values, null, null);
+            } else {
+                if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                    ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_REQUEST_CAMERA + 1);
+                    Toast.makeText(this, "Permissão de armazenamento necessária para salvar o TXT", Toast.LENGTH_LONG).show();
+                    return;
+                }
+                File downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+                if (!downloads.exists() && !downloads.mkdirs()) {
+                    throw new IllegalStateException("Unable to create Downloads directory");
+                }
+                File target = new File(downloads, name);
+                try (OutputStream outputStream = new FileOutputStream(target)) {
+                    outputStream.write(data);
+                }
+                uri = Uri.fromFile(target);
+            }
+
+            Toast.makeText(this, "TXT salvo em Downloads: " + name, Toast.LENGTH_LONG).show();
+        } catch (Exception e) {
+            Toast.makeText(this, "Falha ao salvar TXT em Downloads", Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,48 +1,47 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_long">Sobre ErikrafT Drop &amp; PairDrop para Android</string>
+    <string name="app_name_long">Sobre o ErikrafT Drop</string>
     <string name="app_name_slogan">Transfira arquivos perfeitamente entre todos os seus dispositivos.</string>
     <string name="err_no_browser">Não foi possível abrir o navegador</string>
     <string name="err_no_app">Nenhum app instalado que pode abrir este arquivo</string>
     <string name="open_url">Abrir URL</string>
-    <!-- Onboarding -->
     <string name="onboarding_button_continue">continuar</string>
     <string name="onboarding_button_grant">fornecer permissão</string>
     <string name="onboarding_button_finish">terminar</string>
     <string name="onboarding_choose_server">Escolha o endereço do servidor</string>
     <string name="onboarding_choose_server_short">escolher servidor</string>
-    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o ErikrafT Drop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma url personalizada para se conectar.\n\nNota: Você tem que escolher a mesma URL em todos os dispositivos.</string>
+    <string name="onboarding_choose_server_description">Este app é um cliente otimizado para o ErikrafT Drop e o PairDrop.\nEscolha uma das seguintes instâncias ou especifique uma URL personalizada para se conectar.\n\nNota: você precisa escolher a mesma URL em todos os dispositivos.</string>
     <string name="onboarding_storage_permission">Permissão de armazenamento</string>
     <string name="onboarding_storage_permission_description">Este aplicativo é usado para compartilhamento de arquivos. Portanto, a permissão de armazenamento é necessária para usá-lo.</string>
-    <string name="onboarding_server_pairdrop_summary">(recomendado)\nrecurso de emparelhamento, transferência de internet e foco na estabilidade.</string>
-    <string name="onboarding_server_snapdrop_summary">O snapdrop clássico. Limpo e simples.</string>
-    <string name="onboarding_server_snapdrop_summary_server_warning">Atenção: Instabilidade no servidor</string>
+    <string name="onboarding_server_primary_summary">(1) Padrão — ErikrafT Drop</string>
+    <string name="onboarding_server_secondary_summary">(2) Secundário — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_tertiary_summary">(3) Terciário — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_quaternary_summary">(4) Quarto — PairDrop (concorrente)</string>
+    <string name="onboarding_server_pairdrop_summary">Servidor padrão do ErikrafT Drop.</string>
+    <string name="onboarding_server_snapdrop_summary">Compartilhamento de arquivos simples e limpo.</string>
+    <string name="onboarding_server_snapdrop_summary_server_warning">Fallback do PairDrop.</string>
     <string name="onboarding_server_custom">URL personalizada</string>
     <string name="onboarding_server_custom_summary">Especialistas também podem hospedar seus próprios servidores.</string>
-    <string name="onboarding_server_custom_add">Add server</string>
+    <string name="onboarding_server_custom_add">Adicionar servidor</string>
     <string name="onboarding_howto">Como usar</string>
     <string name="onboarding_howto_summary">1. Abra este aplicativo ou %s em qualquer outro dispositivo na sua rede Wi-Fi local.\n\n2. Toque no dispositivo e selecione os arquivos que deseja enviar.\n\n3. Pronto! Os arquivos serão enviados…</string>
-    <string name="onboarding_howto_troubleshoot">Dica: Dispositivos precisam estar conectados na mesma rede Wi-Fi. Pode não funcionar se um VPN estiver ativado.</string>
-    <!-- Download -->
-    <string name="download_save_pending">Armazenando o arquivo. Por favor, tenha um pouco de paciência…</string>
-    <string name="download_successful">Transferência feita com sucesso</string>
-    <string name="notification_channel_name">Transferência concluída</string>
-    <!-- Action Buttons -->
+    <string name="onboarding_howto_troubleshoot">Dica: os dispositivos precisam estar conectados à mesma rede Wi-Fi. Pode não funcionar se uma VPN estiver ativada.</string>
+    <string name="download_save_pending">Armazenando o arquivo. Por favor, aguarde…</string>
+    <string name="download_successful">Download concluído</string>
+    <string name="notification_channel_name">Download concluído</string>
     <string name="open">Abrir</string>
     <string name="install">instalar</string>
     <string name="reset">Redefinir</string>
     <string name="copy">Copiar</string>
-    <string name="retry">repetir</string>
-    <!-- Settings / About -->
-    <string name="home_as_up_indicator_about">Informações sobre o \'app\'</string>
-    <string name="title_activity_about">Sobre ErikrafT Drop &amp; PairDrop para Android</string>
-    <string name="pref_about_title">Sobre este \'app\'</string>
+    <string name="retry">tentar novamente</string>
+    <string name="home_as_up_indicator_about">Informações sobre o app</string>
+    <string name="title_activity_about">Sobre o ErikrafT Drop</string>
+    <string name="pref_about_title">Sobre este app</string>
     <string name="view_downloads">Ver downloads</string>
     <string name="pref_category_settings">Configurações</string>
     <string name="logs">Logs de depuração</string>
     <string name="components_summary">Toque para exibir</string>
-    <string name="support_us">Nos ajude</string>
-    <string name="support_us_summary">Veja, como você pode apoiar este projeto</string>
+    <string name="support_us">Apoie-nos</string>
+    <string name="support_us_summary">Veja como você pode apoiar este projeto</string>
     <string name="support_us_description">Ajude a manter o ErikrafT Drop™</string>
     <string name="support_us_option_kofi">Ko-fi</string>
     <string name="support_us_option_pix_kofi">PIX &amp; Ko-fi</string>
@@ -50,20 +49,20 @@
     <string name="version">Versão</string>
     <string name="pref_device_name_title">Nome do dispositivo</string>
     <string name="pref_device_name_summary">Utilizar um nome de dispositivo definido pelo usuário</string>
-    <string name="notifications_summary">Show notification when download is completed</string>
-    <string name="notifications_title">Notifications</string>
-    <string name="keep_on_summary">(Recomendado) Muitos dispositivos têm problemas com transferências interrompidas quando a tela for desligada</string>
+    <string name="notifications_summary">Mostrar notificação quando o download for concluído</string>
+    <string name="notifications_title">Notificações</string>
+    <string name="keep_on_summary">(Recomendado) Muitos dispositivos têm problemas com transferências interrompidas quando a tela é desligada</string>
     <string name="keep_on_title">Manter a tela ligada durante a transferência</string>
     <string name="floating_text_selection_title">Seleção de texto flutuante</string>
     <string name="floating_text_selection_summary">Ao selecionar texto em outros apps, será exibida uma opção \"Enviar via ErikrafT Drop\"</string>
     <string name="show_connectivity_card_title">Aviso de conectividade</string>
-    <string name="show_connectivity_card_summary"> Mostra um aviso quando você não está conectado a uma rede Wi-Fi</string>
+    <string name="show_connectivity_card_summary">Mostrar um aviso quando você não estiver conectado a uma rede Wi-Fi</string>
     <string name="floating_text_selection_activity_label">Enviar via ErikrafT Drop</string>
     <string name="permission_not_granted">Por favor, conceda as permissões necessárias</string>
-    <string name="permission_not_granted_fallback">por favor, conceda a permissão necessária manualmente</string>
+    <string name="permission_not_granted_fallback">Por favor, conceda a permissão necessária manualmente</string>
     <string name="open_settings">Abrir configurações</string>
     <string name="retain_location_metadata_title">Manter metadados de localização</string>
-    <string name="retain_location_metadata_summary_off">Alguns arquivos de mídia podem conter dados de local descarregados por padrão. Conceda permissão para incluir metadados completos</string>
+    <string name="retain_location_metadata_summary_off">Alguns arquivos de mídia podem conter dados de localização que são removidos por padrão. Conceda permissão para incluir metadados completos</string>
     <string name="retain_location_metadata_summary_on">O aplicativo tem acesso total aos arquivos no momento</string>
     <string name="settings_theme_title">Tema</string>
     <string-array name="darkmode_entries">
@@ -75,25 +74,23 @@
     <string name="baseurl_not_set">Não definido</string>
     <string name="baseurl_instance_verified">A instância foi verificada com sucesso</string>
     <string name="baseurl_no_snapdrop_instance">A instância parece não ser suportada</string>
-    <string name="baseurl_check_instance_failed">Falha ao verificar instância</string>
-    <string name="baseurl_unofficial_instances">Verifique <a href="">FAQ</a> para uma lista de versões não oficiais. Atenção, observe que algumas versões podem não funcionar corretamente dentro do \'app\'.</string>
-    <string name="save_location">Salvar localização</string>
-    <!-- File sharing -->
+    <string name="baseurl_check_instance_failed">Falha ao verificar a instância</string>
+    <string name="baseurl_unofficial_instances">Consulte a <a href="">FAQ</a> para obter uma lista de instâncias não oficiais. Algumas podem não funcionar corretamente dentro do app.</string>
+    <string name="save_location">Local para salvar</string>
     <string name="intent_file">Um arquivo foi selecionado para compartilhar</string>
     <string name="intent_files">Arquivos foram selecionados para compartilhar</string>
     <string name="intent_content">O conteúdo foi selecionado para compartilhar</string>
     <string name="error_filechooser">Não é possível abrir o gerenciador de arquivos</string>
-    <string name="error_network">Por favor, certifique-se de que você está conectado a uma rede WiFi</string>
+    <string name="error_network">Verifique se você está conectado a uma rede Wi-Fi</string>
     <string name="error_network_no_wifi">Conecte-se a uma rede Wi-Fi ou pareie dispositivos</string>
     <string name="error_network_offline">Você está desconectado</string>
     <string name="ignore_error_network">Deixe-me prosseguir</string>
     <string name="error_not_reachable_title">Opa, desculpa!</string>
-    <string name="error_server_not_reachable">O servidor não pode ser alcançado. \n\nSe sua conexão de internet está funcionando e isso acontece sempre, por favor, tente selecionar um servidor diferente.</string>
-    <!-- Website Localization -->
+    <string name="error_server_not_reachable">O servidor não pode ser alcançado. \n\nSe sua conexão com a internet estiver funcionando e isso continuar acontecendo, tente selecionar um endereço de servidor diferente.</string>
     <string name="website_no_peers_info">Abra o aplicativo ou site em outros dispositivos para enviar arquivos</string>
-    <string name="website_instruction">Toque para enviar arquivos ou faça toque longo para enviar uma mensagem</string>
+    <string name="website_instruction">Toque para enviar arquivos ou mantenha pressionado para enviar uma mensagem</string>
     <string name="website_file_received">Arquivo recebido</string>
-    <string name="website_file_ask_before_download">Sempre pergunte antes de salvar um arquivo</string>
+    <string name="website_file_ask_before_download">Sempre perguntar antes de salvar um arquivo</string>
     <string name="website_file_download">Salvar</string>
     <string name="website_footer_discovery">Você pode ser descoberto por todas as pessoas nesta rede</string>
     <string name="website_footer_known_as">Você é identificado como %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,9 +15,13 @@
     <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
-    <string name="onboarding_server_pairdrop_summary">(recommended)\nPairing feature, internet transfer and focus on stability.</string>
+    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop</string>
+    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_quaternary_summary">(4) Quaternary — PairDrop (competitor)</string>
+    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop primary server.</string>
     <string name="onboarding_server_snapdrop_summary">Simple and clean file sharing.</string>
-    <string name="onboarding_server_snapdrop_summary_server_warning">Warning: Server instabilities</string>
+    <string name="onboarding_server_snapdrop_summary_server_warning">PairDrop fallback.</string>
     <string name="onboarding_server_custom">Custom URL</string>
     <string name="onboarding_server_custom_summary">Experts can also host their own servers.</string>
     <string name="onboarding_server_custom_add">Add server</string>
@@ -109,13 +113,13 @@
     <string name="website_about_subheading">The easiest way to transfer files across devices</string>
 
     <!-- QR Transfer -->
-    <string name="qr_transfer_title">Transferência por QR</string>
-    <string name="qr_transfer_send_title">Enviar por QR Animado</string>
-    <string name="qr_transfer_receive_title">Receber por QR Animado</string>
-    <string name="qr_transfer_instruction">Mantenha o outro dispositivo apontado para este QR Code</string>
-    <string name="qr_transfer_receive_searching">Procurando QR Code…</string>
-    <string name="pause">Pausar</string>
-    <string name="resume">Retomar</string>
-    <string name="cancel">Cancelar</string>
+    <string name="qr_transfer_title">QR Transfer</string>
+    <string name="qr_transfer_send_title">Send via Animated QR</string>
+    <string name="qr_transfer_receive_title">Receive via Animated QR</string>
+    <string name="qr_transfer_instruction">Keep the other device pointed at this QR Code</string>
+    <string name="qr_transfer_receive_searching">Looking for QR Code…</string>
+    <string name="pause">Pause</string>
+    <string name="resume">Resume</string>
+    <string name="cancel">Cancel</string>
 
 </resources>


### PR DESCRIPTION
## Resumo

Atualiza a PR #70 do **ErikrafT Drop™ for Android** para a versão `10.0.4` / versionCode `21`, mantendo uma abordagem conservadora no WebView e sem reescrever o protocolo ERIKRAFT-QR.

### Servidores oficiais e fallback

A seleção de servidores usa uma ordem determinística:

1. `https://drop.erikraft.com/` — **Padrão**
2. `https://drop-fallback.erikraft.com/` — **Secundário**
3. `https://dropfallback.erikraft.com/` — **Terciário**
4. `https://pairdrop.net/` — **Quarto / Concorrente**

Os servidores personalizados continuam disponíveis. PairDrop permanece apenas como último fallback.

### P2P: Web → Android

Foi feita uma análise do caminho de recebimento do WebRTC no Android. O site entrega os chunks binários ao bridge Android em Base64 e o app grava os bytes decodificados no arquivo local.

A conversão Base64 existente é byte-preserving e o teste de integridade já cobre múltiplos tamanhos/chunk sizes. Portanto, não foi feita uma reimplementação do protocolo WebRTC, pois isso seria uma mudança desnecessariamente complexa e poderia introduzir regressões.

A camada Android foi endurecida de forma segura:

- chamadas `onBytes()` serializadas para impedir interleaving de escritas;
- estado do arquivo reinicializado no início/cancelamento;
- contagem real de bytes recebidos;
- tamanho esperado comparado no encerramento da transferência;
- arquivos incompletos/mismatched são removidos e não entram na lista de downloads;
- o log diferencia uma transferência concluída de uma transferência com tamanho inconsistente.

Isso ataca especificamente o ponto mais sensível do caminho **site → app**, sem alterar o protocolo de transferência do site.

### P2P: Android → Web

O caminho inverso foi analisado. O Android utiliza o seletor nativo e entrega o `Uri` selecionado ao `<input type=file>` do WebView, deixando o envio P2P ser realizado pela implementação existente do site/WebRTC.

Não foi identificada uma segunda camada de conversão Base64/bytes nesse sentido que justificasse uma alteração invasiva. Portanto, nenhuma mudança complexa foi feita no envio **Android → site**, preservando o caminho já existente.

### Downloads e QR

- Downloads do WebChat no Android WebView continuam suportando `blob:`, `data:` e HTTP(S) em links com `download`.
- Imagens e `.txt` gerados pelos dialogs podem ser salvos pela bridge nativa.
- Transferência por QR Animado permanece intacta.
- Fountain FEC, CRC32, SHA-256 e reconstrução não foram reescritos.
- A permissão `CAMERA` continua sendo solicitada somente quando necessária para o leitor de QR.

### Google Play / API

- `compileSdk 36`
- `targetSdkVersion 36` — Android 16 / API 36
- versionCode `21`
- versionName `10.0.4`

### Segurança e compatibilidade

- Nenhum segredo ou keystore é colocado no código.
- A bridge de downloads continua sanitizando nomes de arquivo.
- Não foram adicionadas dependências externas para resolver o P2P.
- Não foram feitas alterações desnecessárias no protocolo QR.
- O submódulo web continua sendo atualizado pelo pipeline a partir do `master`.

### Validação

O pipeline de release continua preparado para Android 16/API 36, APK + AAB assinados e verificação das assinaturas. O build de release assinado depende dos secrets de assinatura configurados no GitHub Actions.

A validação física de uma transferência P2P requer teste com dois dispositivos reais (Web/PC ↔ Android), portanto o código não deve ser considerado empiricamente validado até esse teste ser executado. O endurecimento aplicado evita que uma transferência com tamanho diferente seja silenciosamente tratada como válida.
