### PR TITLE
fix: unblock signed APK/AAB pipeline EKQR tests

### DIFF
--- a/app/src/main/java/com/erikraft/drop/qr/ErikrafTQRProtocol.java
+++ b/app/src/main/java/com/erikraft/drop/qr/ErikrafTQRProtocol.java
@@ -11,7 +11,7 @@ import java.util.zip.CRC32;
 
 /**
  * EKQR v1 wire protocol shared with the ErikrafT Drop web client.
- * The JSON field names intentionally match public/scripts/erikraft-qr.js.
+ * The canonical field names intentionally match public/scripts/erikraft-qr.js.
  */
 public class ErikrafTQRProtocol {
 
@@ -67,9 +67,9 @@ public class ErikrafTQRProtocol {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(data);
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(hash.length * 2);
             for (byte b : hash) {
-                sb.append(String.format("%02x", b));
+                sb.append(String.format("%02x", b & 0xff));
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {
@@ -77,6 +77,7 @@ public class ErikrafTQRProtocol {
         }
     }
 
+    /** Encodes only the canonical v1 Web-compatible schema. */
     public static String encodeFrame(Frame frame) {
         try {
             JSONObject json = new JSONObject();
@@ -106,33 +107,58 @@ public class ErikrafTQRProtocol {
         }
     }
 
+    /**
+     * Decodes canonical Web v1 frames and the pre-canonical Android schema used by
+     * older app builds. Legacy input is normalized into the current Frame model so
+     * the receiver/FEC layer does not need separate code paths.
+     */
     public static Frame decodeFrame(String frameStr) {
         if (frameStr == null || frameStr.trim().isEmpty()) return null;
         try {
             JSONObject json = new JSONObject(frameStr);
-            if (!MAGIC.equals(json.optString("h"))) return null;
-            if (json.optInt("v", -1) != VERSION) return null;
+            boolean canonical = MAGIC.equals(json.optString("h"));
+            boolean legacy = !canonical && MAGIC.equals(json.optString("m"));
+            if (!canonical && !legacy) return null;
+
+            int version = json.optInt("v", -1);
+            if (version != VERSION) return null;
 
             Frame frame = new Frame();
             frame.magic = MAGIC;
             frame.version = VERSION;
-            frame.id = json.optString("id", "");
-            frame.type = json.optString("t", "file");
-            frame.name = json.optString("name", "file.bin");
-            frame.mime = json.optString("mime", "application/octet-stream");
-            frame.size = json.optLong("sz", -1);
-            frame.seq = json.optInt("i", -1);
-            frame.k = json.optInt("n", -1);
-            frame.compressed = json.optInt("c", 0);
-            frame.crc = json.optLong("crc", -1);
-            frame.sha256 = json.optString("sha", "");
-            frame.data = json.optString("d", "");
 
-            if (json.has("fec")) {
-                org.json.JSONArray fec = json.optJSONArray("fec");
-                if (fec != null && fec.length() == 2) {
-                    frame.fec = new int[]{fec.optInt(0, -1), fec.optInt(1, -1)};
+            if (canonical) {
+                frame.id = json.optString("id", "");
+                frame.type = json.optString("t", "file");
+                frame.name = json.optString("name", "file.bin");
+                frame.mime = json.optString("mime", "application/octet-stream");
+                frame.size = json.optLong("sz", -1);
+                frame.seq = json.optInt("i", -1);
+                frame.k = json.optInt("n", -1);
+                frame.compressed = json.optInt("c", 0);
+                frame.crc = json.optLong("crc", -1);
+                frame.sha256 = json.optString("sha", "");
+                frame.data = json.optString("d", "");
+
+                if (json.has("fec")) {
+                    org.json.JSONArray fec = json.optJSONArray("fec");
+                    if (fec != null && fec.length() == 2) {
+                        frame.fec = new int[]{fec.optInt(0, -1), fec.optInt(1, -1)};
+                    }
                 }
+            } else {
+                // Legacy Android v1 field mapping: m/id/t/n/mime/s/k/seq/hash/d/crc.
+                frame.id = json.optString("id", "");
+                frame.type = json.optString("t", "file");
+                frame.name = json.optString("n", "file.bin");
+                frame.mime = json.optString("mime", "application/octet-stream");
+                frame.size = json.optLong("s", -1);
+                frame.k = json.optInt("k", -1);
+                frame.seq = json.optInt("seq", -1);
+                frame.compressed = json.optInt("c", 0);
+                frame.crc = json.optLong("crc", -1);
+                frame.sha256 = json.optString("hash", "");
+                frame.data = json.optString("d", "");
             }
 
             if (frame.id.isEmpty() || frame.size < 0 || frame.k <= 0 || frame.k > 100000

--- a/app/src/test/java/com/erikraft/drop/qr/ErikrafTQRProtocolTest.java
+++ b/app/src/test/java/com/erikraft/drop/qr/ErikrafTQRProtocolTest.java
@@ -3,12 +3,41 @@ package com.erikraft.drop.qr;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 
 public class ErikrafTQRProtocolTest {
+
+    @Test
+    public void testErikrafTQRProtocolEncodingAndDecoding() {
+        byte[] data = "hello from Android".getBytes(StandardCharsets.UTF_8);
+        ErikrafTQRProtocol.Frame frame = new ErikrafTQRProtocol.Frame();
+        frame.id = "TEST1234";
+        frame.type = "text";
+        frame.name = "text.txt";
+        frame.mime = "text/plain";
+        frame.size = data.length;
+        frame.k = 1;
+        frame.seq = 0;
+        frame.compressed = 0;
+        frame.data = ErikrafTQRProtocol.encodeBase64(data);
+        frame.crc = ErikrafTQRProtocol.computeCRC32(frame.data);
+        frame.sha256 = ErikrafTQRProtocol.computeSHA256(data);
+
+        String encoded = ErikrafTQRProtocol.encodeFrame(frame);
+        assertTrue(encoded.contains("\"h\":\"EKQR\""));
+        assertTrue(encoded.contains("\"sz\":" + data.length));
+
+        ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(encoded);
+        assertNotNull(decoded);
+        assertEquals("TEST1234", decoded.id);
+        assertEquals("text.txt", decoded.name);
+        assertEquals(ErikrafTQRProtocol.computeSHA256(data), decoded.sha256);
+        assertArrayEquals(data, ErikrafTQRProtocol.decodeBase64(decoded.data));
+    }
 
     @Test
     public void androidFrameUsesWebCompatibleSchema() {
@@ -28,13 +57,11 @@ public class ErikrafTQRProtocolTest {
 
         String encoded = ErikrafTQRProtocol.encodeFrame(frame);
         assertNotNull(encoded);
-        assertEquals(ErikrafTQRProtocol.MAGIC, ErikrafTQRProtocol.decodeFrame(encoded).magic);
-
-        ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(encoded);
-        assertNotNull(decoded);
-        assertEquals("TEST1234", decoded.id);
-        assertEquals("text.txt", decoded.name);
-        assertArrayEquals(data, ErikrafTQRProtocol.decodeBase64(decoded.data));
+        assertNotNull(ErikrafTQRProtocol.decodeFrame(encoded));
+        assertTrue(encoded.contains("\"name\":\"text.txt\""));
+        assertTrue(encoded.contains("\"i\":0"));
+        assertTrue(encoded.contains("\"n\":1"));
+        assertTrue(encoded.contains("\"sha\":\""));
     }
 
     @Test
@@ -50,5 +77,25 @@ public class ErikrafTQRProtocolTest {
         assertNotNull(decoded);
         assertEquals("WEB12345", decoded.id);
         assertEquals(0, decoded.compressed);
+        assertEquals(sha, decoded.sha256);
+        assertArrayEquals("Hello".getBytes(StandardCharsets.UTF_8),
+                ErikrafTQRProtocol.decodeBase64(decoded.data));
+    }
+
+    @Test
+    public void legacyAndroidFrameSchemaIsAccepted() {
+        String payload = ErikrafTQRProtocol.encodeBase64("Legacy".getBytes(StandardCharsets.UTF_8));
+        String json = "{\"m\":\"EKQR\",\"v\":1,\"id\":\"LEGACY1\",\"t\":\"text\","
+                + "\"n\":\"legacy.txt\",\"mime\":\"text/plain\",\"s\":6,\"k\":1,\"seq\":0,"
+                + "\"crc\":" + ErikrafTQRProtocol.computeCRC32(payload)
+                + ",\"hash\":\"" + ErikrafTQRProtocol.computeSHA256("Legacy".getBytes(StandardCharsets.UTF_8))
+                + "\",\"d\":\"" + payload + "\"}";
+
+        ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(json);
+        assertNotNull(decoded);
+        assertEquals("LEGACY1", decoded.id);
+        assertEquals("legacy.txt", decoded.name);
+        assertArrayEquals("Legacy".getBytes(StandardCharsets.UTF_8),
+                ErikrafTQRProtocol.decodeBase64(decoded.data));
     }
 }


### PR DESCRIPTION
## Objetivo
Corrigir a falha do pipeline de release de APK/AAB assinados causada pela suíte de testes EKQR, sem alterar o workflow de assinatura nem o núcleo P2P/WebRTC.

## Diagnóstico
O contrato EKQR precisava ser tratado de forma determinística e compatível com o formato Web atual. Além disso, o decoder Android não tinha compatibilidade de leitura com o formato legado usado por versões anteriores.

## Alterações
- Mantém a geração Android no schema canônico Web EKQR v1 (`h/v/id/t/name/mime/sz/i/n/c/crc/sha/d`).
- Mantém CRC32 calculado sobre a string Base64, igual ao Web.
- Corrige a representação Java do SHA-256 para bytes não assinados, evitando hashes incorretos para bytes acima de `0x7F`.
- Faz o decoder aceitar tanto o schema canônico Web quanto o schema legado Android (`m/n/s/k/seq/hash`).
- Normaliza frames legados para o mesmo modelo interno, sem criar um segundo caminho de FEC/reassembly.
- Mantém validações de versão, tamanho, índices, compressão e CRC.
- Expande `ErikrafTQRProtocolTest` para cobrir o round-trip, schema Android→Web, schema Web→Android e compatibilidade legada.
- Não altera o workflow de signing/keystore, nem desabilita `./gradlew test`.

## Segurança/estabilidade
A correção atua no contrato de serialização/parsing. Não remove testes para fazer o pipeline passar artificialmente e não ignora erros de integridade.

## Validação
O GitHub Actions deve executar os testes desta PR. O pipeline de release continuará bloqueando a assinatura quando `./gradlew test` falhar, como deve ser.