### PR TITLE
🧪｜Fix release pipeline QR protocol unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,6 +148,7 @@ dependencies {
     implementation "com.mikepenz:aboutlibraries-core:11.2.3"
     implementation "com.mikepenz:aboutlibraries:11.2.3"
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.json:json:20250517'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation 'com.anggrayudi:storage:1.5.6'


### PR DESCRIPTION
## Problema

O pipeline de APK/AAB assinado estava parando em `./gradlew test`, antes de qualquer etapa de assinatura. Os quatro variants executados pelo release workflow estavam falhando dentro de `ErikrafTQRProtocolTest`.

## Causa identificada

`ErikrafTQRProtocol` usa `org.json.JSONObject`, mas os testes são unit tests JVM (`test*UnitTest`). Sem uma implementação JVM de `org.json` no classpath de testes, os testes podem resolver a API `org.json` do Android framework e falhar em runtime com os métodos Android não implementados/mocados.

Isso explica o padrão das falhas: tanto a codificação quanto a decodificação retornavam/explodiam antes das asserções de compatibilidade do protocolo.

## Correção

- Adicionada a dependência `testImplementation 'org.json:json:20250517'`.
- A implementação Android em produção continua usando a API `org.json` do Android.
- Nenhuma alteração no workflow de release.
- Nenhuma remoção ou relaxamento dos testes.
- Nenhuma alteração no sistema de assinatura/keystore.
- Os testes continuam verificando o schema Web atual e a compatibilidade legada.

## Objetivo

Permitir que `./gradlew test` execute corretamente em JVM para todos os variants e, consequentemente, desbloquear as etapas seguintes de geração e assinatura de APK/AAB.

## Validação

O GitHub Actions deve validar a correção executando novamente os testes do pipeline. Não foi alterada nenhuma etapa para ignorar falhas.
