### PR TITLE
🧪｜Fix EKQR JVM unit-test pipeline failure

### DIFF
--- a/app/src/main/java/com/erikraft/drop/qr/ErikrafTQRProtocol.java
+++ b/app/src/main/java/com/erikraft/drop/qr/ErikrafTQRProtocol.java
@@ -1,17 +1,18 @@
 package com.erikraft.drop.qr;
 
-import android.util.Log;
-
-import org.json.JSONObject;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.CRC32;
 
 /**
  * EKQR v1 wire protocol shared with the ErikrafT Drop web client.
- * The canonical field names intentionally match public/scripts/erikraft-qr.js.
+ * This class intentionally has no dependency on Android JSON APIs so the same
+ * implementation can be executed by Gradle JVM unit tests and on Android.
  */
 public class ErikrafTQRProtocol {
 
@@ -38,7 +39,7 @@ public class ErikrafTQRProtocol {
     public static byte[] decodeBase64(String str) {
         try {
             return java.util.Base64.getDecoder().decode(str);
-        } catch (Throwable e) {
+        } catch (Throwable ignored) {
             return android.util.Base64.decode(str, android.util.Base64.DEFAULT);
         }
     }
@@ -46,7 +47,7 @@ public class ErikrafTQRProtocol {
     public static String encodeBase64(byte[] data) {
         try {
             return java.util.Base64.getEncoder().encodeToString(data);
-        } catch (Throwable e) {
+        } catch (Throwable ignored) {
             return android.util.Base64.encodeToString(data, android.util.Base64.NO_WRAP);
         }
     }
@@ -79,48 +80,88 @@ public class ErikrafTQRProtocol {
 
     /** Encodes only the canonical v1 Web-compatible schema. */
     public static String encodeFrame(Frame frame) {
-        try {
-            JSONObject json = new JSONObject();
-            json.put("h", MAGIC);
-            json.put("v", frame.version);
-            json.put("id", frame.id != null ? frame.id : "");
-            json.put("t", frame.type != null ? frame.type : "file");
-            json.put("name", frame.name != null ? frame.name : "file.bin");
-            json.put("mime", frame.mime != null ? frame.mime : "application/octet-stream");
-            json.put("sz", frame.size);
-            json.put("i", frame.seq);
-            json.put("n", frame.k);
-            json.put("c", frame.compressed);
-            json.put("crc", frame.crc);
-            json.put("sha", frame.sha256 != null ? frame.sha256 : "");
-            json.put("d", frame.data != null ? frame.data : "");
-            if (frame.fec != null && frame.fec.length == 2) {
-                org.json.JSONArray fec = new org.json.JSONArray();
-                fec.put(frame.fec[0]);
-                fec.put(frame.fec[1]);
-                json.put("fec", fec);
-            }
-            return json.toString();
-        } catch (Exception e) {
-            Log.e("ErikrafTQRProtocol", "Unable to encode EKQR frame", e);
-            return "";
+        StringBuilder json = new StringBuilder(256);
+        json.append('{');
+        appendString(json, "h", MAGIC);
+        appendNumber(json, "v", frame.version);
+        appendString(json, "id", frame.id != null ? frame.id : "");
+        appendString(json, "t", frame.type != null ? frame.type : "file");
+        appendString(json, "name", frame.name != null ? frame.name : "file.bin");
+        appendString(json, "mime", frame.mime != null ? frame.mime : "application/octet-stream");
+        appendNumber(json, "sz", frame.size);
+        appendNumber(json, "i", frame.seq);
+        appendNumber(json, "n", frame.k);
+        appendNumber(json, "c", frame.compressed);
+        appendNumber(json, "crc", frame.crc);
+        appendString(json, "sha", frame.sha256 != null ? frame.sha256 : "");
+        appendString(json, "d", frame.data != null ? frame.data : "");
+        if (frame.fec != null && frame.fec.length == 2) {
+            appendComma(json);
+            appendJsonString(json, "fec");
+            json.append(':').append('[').append(frame.fec[0]).append(',').append(frame.fec[1]).append(']');
         }
+        json.append('}');
+        return json.toString();
+    }
+
+    private static void appendString(StringBuilder json, String key, String value) {
+        appendComma(json);
+        appendJsonString(json, key);
+        json.append(':');
+        appendJsonString(json, value);
+    }
+
+    private static void appendNumber(StringBuilder json, String key, long value) {
+        appendComma(json);
+        appendJsonString(json, key);
+        json.append(':').append(value);
+    }
+
+    private static void appendComma(StringBuilder json) {
+        if (json.length() > 1 && json.charAt(json.length() - 1) != '{' && json.charAt(json.length() - 1) != ',') {
+            json.append(',');
+        }
+    }
+
+    private static void appendJsonString(StringBuilder json, String value) {
+        json.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"': json.append("\\\""); break;
+                case '\\': json.append("\\\\"); break;
+                case '\b': json.append("\\b"); break;
+                case '\f': json.append("\\f"); break;
+                case '\n': json.append("\\n"); break;
+                case '\r': json.append("\\r"); break;
+                case '\t': json.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        json.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        json.append(c);
+                    }
+            }
+        }
+        json.append('"');
     }
 
     /**
      * Decodes canonical Web v1 frames and the pre-canonical Android schema used by
-     * older app builds. Legacy input is normalized into the current Frame model so
-     * the receiver/FEC layer does not need separate code paths.
+     * older app builds. Legacy input is normalized into the current Frame model.
      */
     public static Frame decodeFrame(String frameStr) {
         if (frameStr == null || frameStr.trim().isEmpty()) return null;
         try {
-            JSONObject json = new JSONObject(frameStr);
-            boolean canonical = MAGIC.equals(json.optString("h"));
-            boolean legacy = !canonical && MAGIC.equals(json.optString("m"));
+            Object root = new JsonParser(frameStr).parse();
+            if (!(root instanceof Map)) return null;
+            Map<?, ?> json = (Map<?, ?>) root;
+
+            boolean canonical = MAGIC.equals(stringValue(json.get("h")));
+            boolean legacy = !canonical && MAGIC.equals(stringValue(json.get("m")));
             if (!canonical && !legacy) return null;
 
-            int version = json.optInt("v", -1);
+            int version = intValue(json.get("v"), -1);
             if (version != VERSION) return null;
 
             Frame frame = new Frame();
@@ -128,37 +169,38 @@ public class ErikrafTQRProtocol {
             frame.version = VERSION;
 
             if (canonical) {
-                frame.id = json.optString("id", "");
-                frame.type = json.optString("t", "file");
-                frame.name = json.optString("name", "file.bin");
-                frame.mime = json.optString("mime", "application/octet-stream");
-                frame.size = json.optLong("sz", -1);
-                frame.seq = json.optInt("i", -1);
-                frame.k = json.optInt("n", -1);
-                frame.compressed = json.optInt("c", 0);
-                frame.crc = json.optLong("crc", -1);
-                frame.sha256 = json.optString("sha", "");
-                frame.data = json.optString("d", "");
+                frame.id = stringValue(json.get("id"), "");
+                frame.type = stringValue(json.get("t"), "file");
+                frame.name = stringValue(json.get("name"), "file.bin");
+                frame.mime = stringValue(json.get("mime"), "application/octet-stream");
+                frame.size = longValue(json.get("sz"), -1);
+                frame.seq = intValue(json.get("i"), -1);
+                frame.k = intValue(json.get("n"), -1);
+                frame.compressed = intValue(json.get("c"), 0);
+                frame.crc = longValue(json.get("crc"), -1);
+                frame.sha256 = stringValue(json.get("sha"), "");
+                frame.data = stringValue(json.get("d"), "");
 
-                if (json.has("fec")) {
-                    org.json.JSONArray fec = json.optJSONArray("fec");
-                    if (fec != null && fec.length() == 2) {
-                        frame.fec = new int[]{fec.optInt(0, -1), fec.optInt(1, -1)};
+                Object fecValue = json.get("fec");
+                if (fecValue instanceof List) {
+                    List<?> fec = (List<?>) fecValue;
+                    if (fec.size() == 2) {
+                        frame.fec = new int[]{intValue(fec.get(0), -1), intValue(fec.get(1), -1)};
                     }
                 }
             } else {
                 // Legacy Android v1 field mapping: m/id/t/n/mime/s/k/seq/hash/d/crc.
-                frame.id = json.optString("id", "");
-                frame.type = json.optString("t", "file");
-                frame.name = json.optString("n", "file.bin");
-                frame.mime = json.optString("mime", "application/octet-stream");
-                frame.size = json.optLong("s", -1);
-                frame.k = json.optInt("k", -1);
-                frame.seq = json.optInt("seq", -1);
-                frame.compressed = json.optInt("c", 0);
-                frame.crc = json.optLong("crc", -1);
-                frame.sha256 = json.optString("hash", "");
-                frame.data = json.optString("d", "");
+                frame.id = stringValue(json.get("id"), "");
+                frame.type = stringValue(json.get("t"), "file");
+                frame.name = stringValue(json.get("n"), "file.bin");
+                frame.mime = stringValue(json.get("mime"), "application/octet-stream");
+                frame.size = longValue(json.get("s"), -1);
+                frame.k = intValue(json.get("k"), -1);
+                frame.seq = intValue(json.get("seq"), -1);
+                frame.compressed = intValue(json.get("c"), 0);
+                frame.crc = longValue(json.get("crc"), -1);
+                frame.sha256 = stringValue(json.get("hash"), "");
+                frame.data = stringValue(json.get("d"), "");
             }
 
             if (frame.id.isEmpty() || frame.size < 0 || frame.k <= 0 || frame.k > 100000
@@ -172,8 +214,171 @@ public class ErikrafTQRProtocol {
             // Decode once here so malformed Base64 never reaches the FEC/reassembly layer.
             decodeBase64(frame.data);
             return frame;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return null;
+        }
+    }
+
+    private static String stringValue(Object value) {
+        return value instanceof String ? (String) value : "";
+    }
+
+    private static String stringValue(Object value, String fallback) {
+        return value instanceof String ? (String) value : fallback;
+    }
+
+    private static int intValue(Object value, int fallback) {
+        if (value instanceof Number) return ((Number) value).intValue();
+        return fallback;
+    }
+
+    private static long longValue(Object value, long fallback) {
+        if (value instanceof Number) return ((Number) value).longValue();
+        return fallback;
+    }
+
+    /** Minimal JSON parser for the small, fixed EKQR object schema. */
+    private static final class JsonParser {
+        private final String input;
+        private int index;
+
+        JsonParser(String input) {
+            this.input = input;
+        }
+
+        Object parse() {
+            skipWhitespace();
+            Object value = parseValue();
+            skipWhitespace();
+            if (index != input.length()) throw new IllegalArgumentException("Trailing JSON data");
+            return value;
+        }
+
+        private Object parseValue() {
+            skipWhitespace();
+            if (index >= input.length()) throw new IllegalArgumentException("Unexpected end of JSON");
+            char c = input.charAt(index);
+            if (c == '{') return parseObject();
+            if (c == '[') return parseArray();
+            if (c == '"') return parseString();
+            if (c == '-' || (c >= '0' && c <= '9')) return parseNumber();
+            if (input.startsWith("true", index)) { index += 4; return Boolean.TRUE; }
+            if (input.startsWith("false", index)) { index += 5; return Boolean.FALSE; }
+            if (input.startsWith("null", index)) { index += 4; return null; }
+            throw new IllegalArgumentException("Invalid JSON value");
+        }
+
+        private Map<String, Object> parseObject() {
+            expect('{');
+            Map<String, Object> object = new HashMap<>();
+            skipWhitespace();
+            if (peek('}')) { index++; return object; }
+            while (true) {
+                skipWhitespace();
+                String key = parseString();
+                skipWhitespace();
+                expect(':');
+                object.put(key, parseValue());
+                skipWhitespace();
+                if (peek('}')) { index++; return object; }
+                expect(',');
+            }
+        }
+
+        private List<Object> parseArray() {
+            expect('[');
+            List<Object> array = new ArrayList<>();
+            skipWhitespace();
+            if (peek(']')) { index++; return array; }
+            while (true) {
+                array.add(parseValue());
+                skipWhitespace();
+                if (peek(']')) { index++; return array; }
+                expect(',');
+            }
+        }
+
+        private String parseString() {
+            expect('"');
+            StringBuilder value = new StringBuilder();
+            while (index < input.length()) {
+                char c = input.charAt(index++);
+                if (c == '"') return value.toString();
+                if (c != '\\') {
+                    if (c < 0x20) throw new IllegalArgumentException("Invalid control character");
+                    value.append(c);
+                    continue;
+                }
+                if (index >= input.length()) throw new IllegalArgumentException("Invalid escape");
+                char escaped = input.charAt(index++);
+                switch (escaped) {
+                    case '"': value.append('"'); break;
+                    case '\\': value.append('\\'); break;
+                    case '/': value.append('/'); break;
+                    case 'b': value.append('\b'); break;
+                    case 'f': value.append('\f'); break;
+                    case 'n': value.append('\n'); break;
+                    case 'r': value.append('\r'); break;
+                    case 't': value.append('\t'); break;
+                    case 'u':
+                        if (index + 4 > input.length()) throw new IllegalArgumentException("Invalid unicode escape");
+                        int code = Integer.parseInt(input.substring(index, index + 4), 16);
+                        value.append((char) code);
+                        index += 4;
+                        break;
+                    default: throw new IllegalArgumentException("Invalid escape");
+                }
+            }
+            throw new IllegalArgumentException("Unterminated JSON string");
+        }
+
+        private Number parseNumber() {
+            int start = index;
+            if (peek('-')) index++;
+            if (index >= input.length()) throw new IllegalArgumentException("Invalid number");
+            if (peek('0')) {
+                index++;
+            } else {
+                if (!isDigit(input.charAt(index))) throw new IllegalArgumentException("Invalid number");
+                while (index < input.length() && isDigit(input.charAt(index))) index++;
+            }
+            boolean decimal = false;
+            if (peek('.')) {
+                decimal = true;
+                index++;
+                if (index >= input.length() || !isDigit(input.charAt(index))) throw new IllegalArgumentException("Invalid number");
+                while (index < input.length() && isDigit(input.charAt(index))) index++;
+            }
+            if (peek('e') || peek('E')) {
+                decimal = true;
+                index++;
+                if (peek('+') || peek('-')) index++;
+                if (index >= input.length() || !isDigit(input.charAt(index))) throw new IllegalArgumentException("Invalid number");
+                while (index < input.length() && isDigit(input.charAt(index))) index++;
+            }
+            String number = input.substring(start, index);
+            return decimal ? Double.valueOf(number) : Long.valueOf(number);
+        }
+
+        private boolean isDigit(char c) {
+            return c >= '0' && c <= '9';
+        }
+
+        private boolean peek(char expected) {
+            return index < input.length() && input.charAt(index) == expected;
+        }
+
+        private void expect(char expected) {
+            if (!peek(expected)) throw new IllegalArgumentException("Expected '" + expected + "'");
+            index++;
+        }
+
+        private void skipWhitespace() {
+            while (index < input.length()) {
+                char c = input.charAt(index);
+                if (c == ' ' || c == '\t' || c == '\n' || c == '\r') index++;
+                else break;
+            }
         }
     }
 }


### PR DESCRIPTION
## Problema

O pipeline `Signed APK + AAB Release Pipeline` está falhando antes da assinatura, em `:app:testMobileDebugUnitTest`. O mesmo conjunto de testes do protocolo EKQR também é executado nos demais variants.

A correção anterior adicionou `org.json:json` como dependência de teste, mas o erro continuou ocorrendo. Portanto, não devemos continuar dependendo da ordem/classpath entre `android.jar` e uma implementação JVM de `org.json`.

## Causa técnica

`ErikrafTQRProtocol` é usado por testes JVM (`test*UnitTest`) e pelo app Android. O código dependia diretamente de `org.json.JSONObject`/`JSONArray` e de `android.util.Log`. Em testes locais JVM do Android Gradle Plugin, APIs do framework podem ser resolvidas como stubs Android, causando falhas em runtime.

## Correção aplicada

- Removida a dependência de `org.json` do caminho de execução do protocolo EKQR.
- Implementado um parser JSON pequeno e restrito ao formato EKQR v1 dentro de `ErikrafTQRProtocol`.
- Mantida a serialização JSON compatível com o schema Web atual:
  - `h`, `v`, `id`, `t`, `name`, `mime`, `sz`, `i`, `n`, `c`, `crc`, `sha`, `d`
  - `fec` opcional com dois índices para XOR parity.
- Mantido suporte ao schema Android legado (`m`, `n`, `s`, `k`, `seq`, `hash`).
- Mantidas as validações de versão, tamanho, índices, compressão, CRC32 e Base64.
- Removido o uso de `Log.e` no tratamento de erro desse protocolo, evitando outra dependência de stub Android nos testes JVM.
- Nenhuma alteração no WebRTC/P2P, Animated QR/FEC, downloads, WebView ou assinatura.
- Nenhum teste foi removido ou relaxado.

## Objetivo

Fazer `./gradlew test` passar de forma determinística nos variants JVM e permitir que o workflow avance para a geração e assinatura do APK/AAB.

## Validação

A validação final deve ser feita pelo GitHub Actions no novo PR. Não foi possível executar o Gradle diretamente neste ambiente. O workflow continua exigindo todos os testes antes das etapas de keystore/assinatura.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated QR frame encoding and decoding to use a self-contained JSON handling implementation.
  - Removed reliance on external JSON and logging utilities within QR protocol processing.
  - Encoding failures now propagate instead of being silently converted to empty output.
  - Preserved existing Base64 encoding and decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->