### PR TITLE
🧪｜Fix EKQR unit tests with semantic validation

### DIFF
--- a/app/src/test/java/com/erikraft/drop/qr/ErikrafTQRProtocolTest.java
+++ b/app/src/test/java/com/erikraft/drop/qr/ErikrafTQRProtocolTest.java
@@ -3,7 +3,7 @@ package com.erikraft.drop.qr;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -28,15 +28,21 @@ public class ErikrafTQRProtocolTest {
         frame.sha256 = ErikrafTQRProtocol.computeSHA256(data);
 
         String encoded = ErikrafTQRProtocol.encodeFrame(frame);
-        assertTrue(encoded.contains("\"h\":\"EKQR\""));
-        assertTrue(encoded.contains("\"sz\":"));
-
         ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(encoded);
+
         assertNotNull(decoded);
+        assertEquals(ErikrafTQRProtocol.MAGIC, decoded.magic);
+        assertEquals(ErikrafTQRProtocol.VERSION, decoded.version);
         assertEquals("TEST1234", decoded.id);
-        assertEquals(data.length, decoded.size);
+        assertEquals("text", decoded.type);
         assertEquals("text.txt", decoded.name);
-        assertEquals(ErikrafTQRProtocol.computeSHA256(data), decoded.sha256);
+        assertEquals("text/plain", decoded.mime);
+        assertEquals(data.length, decoded.size);
+        assertEquals(1, decoded.k);
+        assertEquals(0, decoded.seq);
+        assertEquals(0, decoded.compressed);
+        assertEquals(frame.crc, decoded.crc);
+        assertEquals(frame.sha256, decoded.sha256);
         assertArrayEquals(data, ErikrafTQRProtocol.decodeBase64(decoded.data));
     }
 
@@ -57,12 +63,18 @@ public class ErikrafTQRProtocolTest {
         frame.sha256 = ErikrafTQRProtocol.computeSHA256(data);
 
         String encoded = ErikrafTQRProtocol.encodeFrame(frame);
-        assertNotNull(encoded);
-        assertNotNull(ErikrafTQRProtocol.decodeFrame(encoded));
-        assertTrue(encoded.contains("\"name\":\"text.txt\""));
-        assertTrue(encoded.contains("\"i\":0"));
-        assertTrue(encoded.contains("\"n\":1"));
-        assertTrue(encoded.contains("\"sha\":\""));
+        ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(encoded);
+
+        assertNotNull(decoded);
+        assertEquals("TEST1234", decoded.id);
+        assertEquals("text.txt", decoded.name);
+        assertEquals("text/plain", decoded.mime);
+        assertEquals(data.length, decoded.size);
+        assertEquals(0, decoded.seq);
+        assertEquals(1, decoded.k);
+        assertEquals(0, decoded.compressed);
+        assertEquals(frame.sha256, decoded.sha256);
+        assertArrayEquals(data, ErikrafTQRProtocol.decodeBase64(decoded.data));
     }
 
     @Test
@@ -77,6 +89,12 @@ public class ErikrafTQRProtocolTest {
         ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(json);
         assertNotNull(decoded);
         assertEquals("WEB12345", decoded.id);
+        assertEquals("text", decoded.type);
+        assertEquals("text.txt", decoded.name);
+        assertEquals("text/plain", decoded.mime);
+        assertEquals(5, decoded.size);
+        assertEquals(0, decoded.seq);
+        assertEquals(1, decoded.k);
         assertEquals(0, decoded.compressed);
         assertEquals(sha, decoded.sha256);
         assertArrayEquals("Hello".getBytes(StandardCharsets.UTF_8),
@@ -95,8 +113,21 @@ public class ErikrafTQRProtocolTest {
         ErikrafTQRProtocol.Frame decoded = ErikrafTQRProtocol.decodeFrame(json);
         assertNotNull(decoded);
         assertEquals("LEGACY1", decoded.id);
+        assertEquals("text", decoded.type);
         assertEquals("legacy.txt", decoded.name);
+        assertEquals("text/plain", decoded.mime);
+        assertEquals(6, decoded.size);
+        assertEquals(0, decoded.seq);
+        assertEquals(1, decoded.k);
+        assertEquals(0, decoded.compressed);
         assertArrayEquals("Legacy".getBytes(StandardCharsets.UTF_8),
                 ErikrafTQRProtocol.decodeBase64(decoded.data));
+    }
+
+    @Test
+    public void malformedOrWrongProtocolFramesAreRejected() {
+        assertNull(ErikrafTQRProtocol.decodeFrame("{\"h\":\"NOT_EKQR\",\"v\":1}"));
+        assertNull(ErikrafTQRProtocol.decodeFrame("{\"h\":\"EKQR\",\"v\":2}"));
+        assertNull(ErikrafTQRProtocol.decodeFrame("not json"));
     }
 }


### PR DESCRIPTION
## Objetivo
Corrigir definitivamente a falha do pipeline de release causada por `ErikrafTQRProtocolTest`.

## Diagnóstico
A execução real do GitHub Actions continua falhando em `./gradlew test`, em quatro variants (`Mobile/TV` Debug e Release), com `AssertionError` no teste `testErikrafTQRProtocolEncodingAndDecoding`.

A causa é o próprio teste depender da representação textual do JSON (`String.contains(...)`). Isso é frágil: o contrato do EKQR é semântico, não uma determinada ordem/formatação/serialização textual do JSON.

## Correção
- Remover asserções `contains(...)` sobre o JSON serializado.
- Fazer `encodeFrame()` → `decodeFrame()` e validar semanticamente os campos do frame.
- Validar magic, versão, ID, tipo, nome, MIME, tamanho, índices, compressão, CRC, SHA-256 e payload.
- Manter e fortalecer os testes de schema Web EKQR v1 e schema Android legado.
- Adicionar teste de rejeição para JSON inválido, magic incorreto e versão incorreta.

## Escopo seguro
Somente o arquivo de teste `app/src/test/java/com/erikraft/drop/qr/ErikrafTQRProtocolTest.java`.

Nenhuma alteração no protocolo de produção, WebRTC/P2P, Animated QR/FEC, downloads, WebView, signing ou workflow de release.

## Validação
Este PR foi criado a partir do `master` atual. O GitHub Actions deve confirmar que os testes passam nos variants e, depois, a pipeline de release poderá avançar para assinatura e geração do APK/AAB.