### PR TITLE
🛠️｜Update custom URL FAQ, Snapdrop warning and release test isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
             echo "is_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run unit tests
-        run: ./gradlew test
+      - name: Run clean unit tests
+        run: ./gradlew clean test --no-build-cache --rerun-tasks
 
       - name: Decode signing keystore
         env:
@@ -83,87 +83,59 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          for value in KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
-            if [ -z "${!value}" ]; then
-              echo "${value} secret is not configured." >&2
-              exit 1
-            fi
-          done
+          test -n "${KEYSTORE_PASSWORD}" || { echo "KEYSTORE_PASSWORD secret is not configured." >&2; exit 1; }
+          test -n "${KEY_ALIAS}" || { echo "KEY_ALIAS secret is not configured." >&2; exit 1; }
+          test -n "${KEY_PASSWORD}" || { echo "KEY_PASSWORD secret is not configured." >&2; exit 1; }
 
       - name: Build signed mobile release APK and AAB
         env:
-          KEYSTORE_PATH: ${{ runner.temp }}/erikraft-release.jks
+          KEYSTORE_FILE: ${{ runner.temp }}/erikraft-release.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          ./gradlew clean assembleMobileRelease bundleMobileRelease
+          ./gradlew clean assembleMobileRelease bundleMobileRelease \
+            -PKEYSTORE_FILE="${KEYSTORE_FILE}" \
+            -PKEYSTORE_PASSWORD="${KEYSTORE_PASSWORD}" \
+            -PKEY_ALIAS="${KEY_ALIAS}" \
+            -PKEY_PASSWORD="${KEY_PASSWORD}"
 
-      - name: Validate and prepare artifacts
+      - name: Validate release artifacts
         run: |
-          APK_PATH="app/build/outputs/apk/mobile/release/Drop-Android.apk"
-          AAB_PATH="app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
+          APK="app/build/outputs/apk/mobile/release/app-mobile-release.apk"
+          AAB="app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
 
-          for artifact in "${APK_PATH}" "${AAB_PATH}"; do
-            if [ ! -f "${artifact}" ]; then
-              echo "Missing artifact: ${artifact}" >&2
-              exit 1
-            fi
+          test -s "${APK}" || { echo "Signed APK was not generated: ${APK}" >&2; exit 1; }
+          test -s "${AAB}" || { echo "Signed AAB was not generated: ${AAB}" >&2; exit 1; }
 
-            if [ ! -s "${artifact}" ]; then
-              echo "Zero-byte artifact: ${artifact}" >&2
-              exit 1
-            fi
-          done
+          echo "APK: ${APK}"
+          echo "AAB: ${AAB}"
 
-          cp "${APK_PATH}" ErikrafT-Drop-release.apk
-          cp "${AAB_PATH}" ErikrafT-Drop-release.aab
+      - name: Verify APK signature
+        run: apksigner verify --verbose "app/build/outputs/apk/mobile/release/app-mobile-release.apk"
 
-          APKSIGNER_PATH=$(find "${ANDROID_HOME}/build-tools" \
-            -type f \
-            -name apksigner \
-            | sort -V \
-            | tail -n 1)
-
-          if [ -z "${APKSIGNER_PATH}" ]; then
-            echo "Unable to locate apksigner in Android SDK." >&2
-            exit 1
-          fi
-
-          "${APKSIGNER_PATH}" verify --verbose ErikrafT-Drop-release.apk
-          jarsigner -verify ErikrafT-Drop-release.aab
-
-          if [ "${{ steps.meta.outputs.is_tag }}" = "true" ]; then
-            cp ErikrafT-Drop-release.apk \
-              "ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.apk"
-
-            cp ErikrafT-Drop-release.aab \
-              "ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.aab"
-          fi
+      - name: Verify AAB signature
+        run: jarsigner -verify -verbose -certs "app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
 
       - name: Upload signed APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: erikraft-drop-apk
-          path: ErikrafT-Drop-release.apk
+          name: erikraft-drop-signed-apk
+          path: app/build/outputs/apk/mobile/release/app-mobile-release.apk
           if-no-files-found: error
 
       - name: Upload signed AAB artifact
         uses: actions/upload-artifact@v4
         with:
-          name: erikraft-drop-aab
-          path: ErikrafT-Drop-release.aab
+          name: erikraft-drop-signed-aab
+          path: app/build/outputs/bundle/mobileRelease/app-mobile-release.aab
           if-no-files-found: error
 
-      - name: Create GitHub release with signed assets
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Create GitHub release
+        if: steps.meta.outputs.is_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.meta.outputs.tag_name }}
           files: |
-            ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.apk
-            ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.aab
-
-      - name: Remove temporary keystore
-        if: always()
-        run: |
-          rm -f "${{ runner.temp }}/erikraft-release.jks"
+            app/build/outputs/apk/mobile/release/app-mobile-release.apk
+            app/build/outputs/bundle/mobileRelease/app-mobile-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             echo "is_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run clean unit tests
+      - name: Run unit tests
         run: ./gradlew clean test --no-build-cache --rerun-tasks
 
       - name: Decode signing keystore
@@ -83,59 +83,87 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          test -n "${KEYSTORE_PASSWORD}" || { echo "KEYSTORE_PASSWORD secret is not configured." >&2; exit 1; }
-          test -n "${KEY_ALIAS}" || { echo "KEY_ALIAS secret is not configured." >&2; exit 1; }
-          test -n "${KEY_PASSWORD}" || { echo "KEY_PASSWORD secret is not configured." >&2; exit 1; }
+          for value in KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+            if [ -z "${!value}" ]; then
+              echo "${value} secret is not configured." >&2
+              exit 1
+            fi
+          done
 
       - name: Build signed mobile release APK and AAB
         env:
-          KEYSTORE_FILE: ${{ runner.temp }}/erikraft-release.jks
+          KEYSTORE_PATH: ${{ runner.temp }}/erikraft-release.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          ./gradlew clean assembleMobileRelease bundleMobileRelease \
-            -PKEYSTORE_FILE="${KEYSTORE_FILE}" \
-            -PKEYSTORE_PASSWORD="${KEYSTORE_PASSWORD}" \
-            -PKEY_ALIAS="${KEY_ALIAS}" \
-            -PKEY_PASSWORD="${KEY_PASSWORD}"
+          ./gradlew clean assembleMobileRelease bundleMobileRelease
 
-      - name: Validate release artifacts
+      - name: Validate and prepare artifacts
         run: |
-          APK="app/build/outputs/apk/mobile/release/app-mobile-release.apk"
-          AAB="app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
+          APK_PATH="app/build/outputs/apk/mobile/release/Drop-Android.apk"
+          AAB_PATH="app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
 
-          test -s "${APK}" || { echo "Signed APK was not generated: ${APK}" >&2; exit 1; }
-          test -s "${AAB}" || { echo "Signed AAB was not generated: ${AAB}" >&2; exit 1; }
+          for artifact in "${APK_PATH}" "${AAB_PATH}"; do
+            if [ ! -f "${artifact}" ]; then
+              echo "Missing artifact: ${artifact}" >&2
+              exit 1
+            fi
 
-          echo "APK: ${APK}"
-          echo "AAB: ${AAB}"
+            if [ ! -s "${artifact}" ]; then
+              echo "Zero-byte artifact: ${artifact}" >&2
+              exit 1
+            fi
+          done
 
-      - name: Verify APK signature
-        run: apksigner verify --verbose "app/build/outputs/apk/mobile/release/app-mobile-release.apk"
+          cp "${APK_PATH}" ErikrafT-Drop-release.apk
+          cp "${AAB_PATH}" ErikrafT-Drop-release.aab
 
-      - name: Verify AAB signature
-        run: jarsigner -verify -verbose -certs "app/build/outputs/bundle/mobileRelease/app-mobile-release.aab"
+          APKSIGNER_PATH=$(find "${ANDROID_HOME}/build-tools" \
+            -type f \
+            -name apksigner \
+            | sort -V \
+            | tail -n 1)
+
+          if [ -z "${APKSIGNER_PATH}" ]; then
+            echo "Unable to locate apksigner in Android SDK." >&2
+            exit 1
+          fi
+
+          "${APKSIGNER_PATH}" verify --verbose ErikrafT-Drop-release.apk
+          jarsigner -verify ErikrafT-Drop-release.aab
+
+          if [ "${{ steps.meta.outputs.is_tag }}" = "true" ]; then
+            cp ErikrafT-Drop-release.apk \
+              "ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.apk"
+
+            cp ErikrafT-Drop-release.aab \
+              "ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.aab"
+          fi
 
       - name: Upload signed APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: erikraft-drop-signed-apk
-          path: app/build/outputs/apk/mobile/release/app-mobile-release.apk
+          name: erikraft-drop-apk
+          path: ErikrafT-Drop-release.apk
           if-no-files-found: error
 
       - name: Upload signed AAB artifact
         uses: actions/upload-artifact@v4
         with:
-          name: erikraft-drop-signed-aab
-          path: app/build/outputs/bundle/mobileRelease/app-mobile-release.aab
+          name: erikraft-drop-aab
+          path: ErikrafT-Drop-release.aab
           if-no-files-found: error
 
-      - name: Create GitHub release
-        if: steps.meta.outputs.is_tag == 'true'
+      - name: Create GitHub release with signed assets
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag_name }}
           files: |
-            app/build/outputs/apk/mobile/release/app-mobile-release.apk
-            app/build/outputs/bundle/mobileRelease/app-mobile-release.aab
+            ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.apk
+            ErikrafT-Drop-${{ steps.meta.outputs.tag_name }}.aab
+
+      - name: Remove temporary keystore
+        if: always()
+        run: |
+          rm -f "${{ runner.temp }}/erikraft-release.jks"

--- a/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
+++ b/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
@@ -124,27 +124,15 @@ public class OnboardingFragment2 extends Fragment {
         pref = PreferenceManager.getDefaultSharedPreferences(requireContext());
         tempUrl.setValue(pref.getString(getString(R.string.pref_baseurl), "https://drop.erikraft.com/"));
 
-        if (tempUrl.getValue().equals("https://snapdrop.net") || tempUrl.getValue().equals("https://pairdrop.net")) {
-            tempUrl.setValue("https://drop.erikraft.com/");
-
-            binding.scrollview.setVisibility(View.INVISIBLE);
-            binding.continueButton.setVisibility(View.INVISIBLE);
-
-            new MaterialAlertDialogBuilder(requireContext())
-                    .setTitle("Important Update")
-                    .setMessage("The snapdrop.net website has been acquired by a company with unclear security and privacy practices. \n\nTo keep your data safe, this app will no longer support snapdrop.net and will instead switch all users to ErikrafT Drop, a more secure alternative.  \n\nThank you for your understanding!")
-                    .setPositiveButton("OK", null)
-                    .setOnDismissListener(dialog -> {
-                        binding.scrollview.setVisibility(View.VISIBLE);
-                        binding.continueButton.setVisibility(View.VISIBLE);
-                    })
-                    .show();
-        }
-
         reloadServerList();
 
-        binding.add.setOnClickListener(v -> ViewUtils.showEditTextWithResetPossibility(this, "Custom URL", null, null, Link.bind("https://github.com/RobinLinus/snapdrop/blob/master/docs/faq.md#inofficial-instances", R.string.baseurl_unofficial_instances), url -> {
+        binding.add.setOnClickListener(v -> ViewUtils.showEditTextWithResetPossibility(this, "Custom URL", null, null, Link.bind("https://github.com/erikraft/Drop/blob/master/docs/FAQ.md", R.string.baseurl_unofficial_instances), url -> {
             if (url == null) {
+                return;
+            }
+
+            if (isSnapdropNet(url)) {
+                showSnapdropUpdateNotice();
                 return;
             }
 
@@ -182,6 +170,35 @@ public class OnboardingFragment2 extends Fragment {
             }
         });
         binding.continueButton.requestFocus();
+    }
+
+    private boolean isSnapdropNet(final String value) {
+        if (value == null) {
+            return false;
+        }
+
+        String normalized = value.trim();
+        if (normalized.startsWith("!!")) {
+            normalized = normalized.substring(2).trim();
+        }
+        if (!normalized.contains("://")) {
+            normalized = "https://" + normalized;
+        }
+        normalized = normalized.replaceFirst("^http://", "https://");
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return "https://snapdrop.net".equalsIgnoreCase(normalized)
+                || "https://www.snapdrop.net".equalsIgnoreCase(normalized);
+    }
+
+    private void showSnapdropUpdateNotice() {
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.important_update_title)
+                .setMessage(R.string.important_update_message)
+                .setPositiveButton(R.string.important_update_ok, (dialog, which) ->
+                        tempUrl.setValue("https://drop.erikraft.com/"))
+                .show();
     }
 
     private void reloadServerList() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="app_name" translatable="false">ErikrafT Drop</string>
-    <string name="app_name_long">ErikrafT Drop</string>
+    <string name="app_name" translatable="false">ErikrafT Drop™</string>
+    <string name="app_name_long">ErikrafT Drop™</string>
     <string name="app_name_slogan">Transfer files seamlessly between all your devices.</string>
     <string name="err_no_browser">Can\'t open browser</string>
     <string name="err_no_app">No app installed to open this file</string>
@@ -15,11 +15,11 @@
     <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
-    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop</string>
-    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop fallback</string>
-    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop™</string>
+    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop™ fallback</string>
+    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop™ fallback</string>
     <string name="onboarding_server_quaternary_summary">(4) Quaternary — PairDrop (competitor)</string>
-    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop primary server.</string>
+    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop™ primary server.</string>
     <string name="onboarding_server_snapdrop_summary">Simple and clean file sharing.</string>
     <string name="onboarding_server_snapdrop_summary_server_warning">PairDrop fallback.</string>
     <string name="onboarding_server_custom">Custom URL</string>
@@ -44,7 +44,7 @@
 
     <!-- Settings / About -->
     <string name="home_as_up_indicator_about">About</string>
-    <string name="title_activity_about">About ErikrafT Drop</string>
+    <string name="title_activity_about">About ErikrafT Drop™</string>
     <string name="pref_about_title">About this app</string>
     <string name="view_downloads">View downloads</string>
     <string name="pref_category_settings">Settings</string>
@@ -64,10 +64,10 @@
     <string name="keep_on_summary">(Recommended) Many devices have problems with transfers being interrupted when the screen turns off</string>
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
-    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with ErikrafT Drop\" will be shown</string>
+    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with ErikrafT Drop™\" will be shown</string>
     <string name="show_connectivity_card_title">Connectivity warning</string>
     <string name="show_connectivity_card_summary"> Show a warning when you are not connected with a WiFi network</string>
-    <string name="floating_text_selection_activity_label">Send with ErikrafT Drop</string>
+    <string name="floating_text_selection_activity_label">Send with ErikrafT Drop™</string>
     <string name="permission_not_granted">please grant the necessary permission</string>
     <string name="permission_not_granted_fallback">please grant the necessary permission manually</string>
     <string name="open_settings">open settings</string>
@@ -86,7 +86,11 @@
     <string name="baseurl_instance_verified">Instance was successfully verified</string>
     <string name="baseurl_no_snapdrop_instance">Instance doesn\'t seem to be supported</string>
     <string name="baseurl_check_instance_failed">Failed to verify instance</string>
-    <string name="baseurl_unofficial_instances">Check out the <a href="">FAQ</a> for a list of unofficial instances. Please note that some instances might not work correctly inside the app.</string>
+    <string name="baseurl_unofficial_instances">Check out the <a href="">FAQ</a> for a list of unofficial and legacy instances. Please note that some instances might not work correctly inside the app.</string>
+
+    <string name="important_update_title">Important Update</string>
+    <string name="important_update_message">The snapdrop.net website has been acquired by a company with unclear security and privacy practices.\n\nTo keep your data safe, this app will no longer support snapdrop.net and will instead switch all users to ErikrafT Drop™, a more secure alternative.\n\nThank you for your understanding!</string>
+    <string name="important_update_ok">OK</string>
 
     <string name="save_location">Save location</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="app_name" translatable="false">ErikrafT Drop™</string>
-    <string name="app_name_long">ErikrafT Drop™</string>
+    <string name="app_name" translatable="false">ErikrafT Drop</string>
+    <string name="app_name_long">ErikrafT Drop</string>
     <string name="app_name_slogan">Transfer files seamlessly between all your devices.</string>
     <string name="err_no_browser">Can\'t open browser</string>
     <string name="err_no_app">No app installed to open this file</string>
@@ -15,11 +15,11 @@
     <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
-    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop™</string>
-    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop™ fallback</string>
-    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop™ fallback</string>
+    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop</string>
+    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop fallback</string>
+    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop fallback</string>
     <string name="onboarding_server_quaternary_summary">(4) Quaternary — PairDrop (competitor)</string>
-    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop™ primary server.</string>
+    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop primary server.</string>
     <string name="onboarding_server_snapdrop_summary">Simple and clean file sharing.</string>
     <string name="onboarding_server_snapdrop_summary_server_warning">PairDrop fallback.</string>
     <string name="onboarding_server_custom">Custom URL</string>
@@ -44,7 +44,7 @@
 
     <!-- Settings / About -->
     <string name="home_as_up_indicator_about">About</string>
-    <string name="title_activity_about">About ErikrafT Drop™</string>
+    <string name="title_activity_about">About ErikrafT Drop</string>
     <string name="pref_about_title">About this app</string>
     <string name="view_downloads">View downloads</string>
     <string name="pref_category_settings">Settings</string>
@@ -64,10 +64,10 @@
     <string name="keep_on_summary">(Recommended) Many devices have problems with transfers being interrupted when the screen turns off</string>
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
-    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with ErikrafT Drop™\" will be shown</string>
+    <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with ErikrafT Drop\" will be shown</string>
     <string name="show_connectivity_card_title">Connectivity warning</string>
     <string name="show_connectivity_card_summary"> Show a warning when you are not connected with a WiFi network</string>
-    <string name="floating_text_selection_activity_label">Send with ErikrafT Drop™</string>
+    <string name="floating_text_selection_activity_label">Send with ErikrafT Drop</string>
     <string name="permission_not_granted">please grant the necessary permission</string>
     <string name="permission_not_granted_fallback">please grant the necessary permission manually</string>
     <string name="open_settings">open settings</string>


### PR DESCRIPTION
## Summary

### Custom URL / FAQ
- Change the Custom URL FAQ link to the new `erikraft/Drop` `docs/FAQ.md`.
- Keep the existing custom-server flow intact.
- Treat Snapdrop as legacy/unofficial in the guidance.

### Snapdrop safety notice
- Remove the previous startup-time notice that also affected PairDrop.
- Show the requested **Important Update** only when the user attempts to add `snapdrop.net` (including `www`, HTTP/HTTPS and trailing slash variants) as a custom server.
- Do not add `snapdrop.net` after the warning.
- Selecting **OK** switches the pending server selection to the official `https://drop.erikraft.com/` instance.
- The notice uses `ErikrafT Drop™` exactly as requested.

### Signed APK + AAB Release Pipeline
- Keep signing, artifact validation and release steps unchanged.
- Run unit tests from a clean Gradle state with `--no-build-cache --rerun-tasks`.
- This specifically addresses the reported EKQR unit-test failure while avoiding any bypass of tests or signing.

## Scope / safety
- No changes to WebRTC/P2P transfer logic, EKQR/FEC protocol implementation, downloads, or Android signing configuration.
- The current semantic EKQR tests on `master` are preserved; this PR does not weaken their assertions.
- The clean uncached test execution is intentionally conservative because the reported `line 32` failure is inconsistent with the current master test/protocol sources and may be caused by stale/cached test outputs.

## Testing
- GitHub Actions should validate the clean unit-test run and then the existing signed APK/AAB pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for Snapdrop.net addresses during server setup.
  - Displays an update notice and provides a direct migration option to ErikrafT Drop.
  - Improved URL handling for common formats, including protocol variations and trailing slashes.

- **Updates**
  - Updated guidance to reference legacy instances.
  - Updated the FAQ link to point to the ErikrafT Drop repository.
  - Added localized text for the update notice and confirmation button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->