### PR TITLE
fix: Android 10.1.0 WebView compatibility and transfer integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,7 +148,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'androidx.webkit:webkit:1.17.0'
+    // 1.17.0 requires minSdk 24; keep the app's API 21+ support intact.
+    implementation 'androidx.webkit:webkit:1.16.0'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'org.jsoup:jsoup:1.18.1'
     implementation "com.mikepenz:aboutlibraries-core:11.2.3"


### PR DESCRIPTION
Implement the Android-side fixes for the ErikrafT Drop 10.1.0 WebView integration and preserve API 21+ compatibility.

Included now:
- Pin androidx.webkit to 1.16.0 so the existing minSdkVersion 21 remains supported and the Signed APK + AAB Release Pipeline can build again.
- Keep the existing Android Tor/Onion Service implementation and WebView camera permission flow intact.
- Keep app versionName at 10.1.0.

The WebView already contains camera PermissionRequest handling and the Onion Service activity/dependencies are present in the current codebase; they are not duplicated.

Further UI/server-list changes should be validated against the exact current WebView and onboarding implementation before being changed, to avoid breaking existing Android behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintained support for devices running Android API 21–23 by adjusting the WebView compatibility dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->