### PR TITLE
fix: restore Android 21 compatibility with WebKit 1.14.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,8 +148,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    // 1.17.0 requires minSdk 24; keep the app's API 21+ support intact.
-    implementation 'androidx.webkit:webkit:1.16.0'
+    // 1.15.0 requires minSdk 23; 1.14.0 is the newest stable WebKit release that keeps API 21 support.
+    implementation 'androidx.webkit:webkit:1.14.0'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'org.jsoup:jsoup:1.18.1'
     implementation "com.mikepenz:aboutlibraries-core:11.2.3"


### PR DESCRIPTION
## Correção do pipeline de release

O pipeline `Signed APK + AAB Release Pipeline` estava falhando em `processMobileDebugMainManifest` porque:

- o aplicativo mantém `minSdkVersion 21`;
- `androidx.webkit:webkit:1.16.0` exige `minSdk 24`;
- portanto o Manifest Merger interrompia o build.

### Alteração

- Mantido `minSdkVersion 21` para preservar compatibilidade com Android 5.0+.
- Alterado `androidx.webkit:webkit` de `1.16.0` para `1.14.0`.

A documentação oficial do AndroidX confirma que o WebKit 1.15.0 elevou o mínimo de API 21 para 23, enquanto o 1.16.0 elevou para 24. O 1.14.0 é a versão estável adequada para manter API 21. citeturn0search1turn0search8

### Importante

Não foi usado `tools:overrideLibrary`, pois isso apenas mascararia a incompatibilidade e poderia causar falhas em runtime.

O objetivo desta PR é corrigir especificamente a falha de compatibilidade que está bloqueando o pipeline de release, sem aumentar o `minSdk` do aplicativo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the AndroidX WebKit version to support API 21 while avoiding the newer release’s higher minimum SDK requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->