### PR TITLE
fix: repair Onion transfer compilation

### DIFF
--- a/app/src/main/java/com/erikraft/drop/OnionTransferActivity.java
+++ b/app/src/main/java/com/erikraft/drop/OnionTransferActivity.java
@@ -16,21 +16,18 @@ import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.common.BitMatrix;
 
-import org.nanohttpd.protocols.http.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,7 +58,7 @@ public class OnionTransferActivity extends AppCompatActivity {
         picker = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             if (result.getResultCode() != RESULT_OK || result.getData() == null) return;
             files.clear();
-            android.content.Intent data = result.getData();
+            Intent data = result.getData();
             ClipData clip = data.getClipData();
             try {
                 if (clip != null) for (int i = 0; i < clip.getItemCount(); i++) files.add(copyToCache(clip.getItemAt(i).getUri()));
@@ -120,7 +117,7 @@ public class OnionTransferActivity extends AppCompatActivity {
             String uri = session.getUri();
             if ("/".equals(uri)) {
                 StringBuilder html = new StringBuilder("<html><meta name='viewport' content='width=device-width'><body><h1>ErikrafT Drop™ Onion</h1><p>Arquivos disponíveis:</p><ul>");
-                for (int i = 0; i < files.size(); i++) { File f = files.get(i); html.append("<li><a download href='/file/").append(i).append("'>").append(escape(f.getName())).append("</a> (" ).append(f.length()).append(" bytes)</li>"); }
+                for (int i = 0; i < files.size(); i++) { File f = files.get(i); html.append("<li><a download href='/file/").append(i).append("'>").append(escape(f.getName())).append("</a> (").append(f.length()).append(" bytes)</li>"); }
                 html.append("</ul></body></html>");
                 return newFixedLengthResponse(Response.Status.OK, "text/html; charset=utf-8", html.toString());
             }

--- a/app/src/main/java/com/erikraft/drop/TorController.java
+++ b/app/src/main/java/com/erikraft/drop/TorController.java
@@ -1,9 +1,7 @@
 package com.erikraft.drop;
 
-import android.app.Application;
 import android.content.Context;
 import android.os.Build;
-import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.webkit.ProxyConfig;
@@ -15,8 +13,6 @@ import org.briarproject.android.dontkillmelib.wakelock.AndroidWakeLockManagerFac
 import org.briarproject.onionwrapper.AndroidTorWrapper;
 import org.briarproject.onionwrapper.TorWrapper;
 
-import java.io.File;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
@@ -29,26 +25,26 @@ public final class TorController implements TorWrapper.Observer {
     private static final int CONTROL_PORT = 53055;
     private static TorController instance;
 
-    private final Application app;
+    private final Context appContext;
     private final AndroidTorWrapper tor;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
-    private final Executor mainExecutor;
+    private final java.util.concurrent.Executor mainExecutor;
     private volatile boolean started;
     private volatile boolean connected;
     private volatile Runnable pendingConnected;
     private volatile OnionCallback pendingOnion;
 
-    private TorController(@NonNull Application app) {
-        this.app = app;
-        AndroidWakeLockManager wakeLockManager = AndroidWakeLockManagerFactory.createAndroidWakeLockManager(app);
+    private TorController(@NonNull Context context) {
+        appContext = context.getApplicationContext();
+        AndroidWakeLockManager wakeLockManager = AndroidWakeLockManagerFactory.createAndroidWakeLockManager(appContext);
         ThreadPoolExecutor ioExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>(), new ThreadPoolExecutor.DiscardPolicy());
-        mainExecutor = app.getMainExecutor();
-        tor = new AndroidTorWrapper(app, wakeLockManager, ioExecutor, mainExecutor, architecture(), app.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
+        mainExecutor = appContext.getMainExecutor();
+        tor = new AndroidTorWrapper(appContext, wakeLockManager, ioExecutor, mainExecutor, architecture(), appContext.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
         tor.setObserver(this);
     }
 
     public static synchronized TorController get(@NonNull Context context) {
-        if (instance == null) instance = new TorController(context.getApplicationContext());
+        if (instance == null) instance = new TorController(context);
         return instance;
     }
 


### PR DESCRIPTION
## Summary

Fixes the Android Java compilation failure in the Onion transfer implementation.

### Changes
- Switch `OnionTransferActivity` from the non-existent `org.nanohttpd.protocols.http.NanoHTTPD` package to the NanoHTTPD 2.3.1 API (`fi.iki.elonen.NanoHTTPD`).
- Restore the valid `NanoHTTPD.Response` / `IHTTPSession` override and inherited `stop()` / `getListeningPort()` API usage.
- Fix `TorController` singleton initialization so it accepts a `Context` and stores its application context instead of passing a `Context` where an `Application` was required.

The existing `minSdkVersion 21` and NanoHTTPD 2.3.1 dependency are preserved.

This PR specifically addresses the `compileMobileDebugJavaWithJavac` / `compileMobileReleaseJavaWithJavac` errors reported by the Android build pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal networking and background service integrations for improved compatibility and maintainability.
  - Simplified application context handling across transfer and connectivity components.
  - Removed unused internal dependencies and streamlined related code without changing the user-facing functionality.
- **Bug Fixes**
  - Improved reliability of embedded transfer-server and connectivity initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->