### PR TITLE
fix: pass Application to Tor wrapper APIs

### DIFF
--- a/app/src/main/java/com/erikraft/drop/TorController.java
+++ b/app/src/main/java/com/erikraft/drop/TorController.java
@@ -1,7 +1,10 @@
 package com.erikraft.drop;
 
+import android.app.Application;
 import android.content.Context;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.webkit.ProxyConfig;
@@ -25,7 +28,7 @@ public final class TorController implements TorWrapper.Observer {
     private static final int CONTROL_PORT = 53055;
     private static TorController instance;
 
-    private final Context appContext;
+    private final Application application;
     private final AndroidTorWrapper tor;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final java.util.concurrent.Executor mainExecutor;
@@ -35,11 +38,11 @@ public final class TorController implements TorWrapper.Observer {
     private volatile OnionCallback pendingOnion;
 
     private TorController(@NonNull Context context) {
-        appContext = context.getApplicationContext();
-        AndroidWakeLockManager wakeLockManager = AndroidWakeLockManagerFactory.createAndroidWakeLockManager(appContext);
+        application = (Application) context.getApplicationContext();
+        AndroidWakeLockManager wakeLockManager = AndroidWakeLockManagerFactory.createAndroidWakeLockManager(application);
         ThreadPoolExecutor ioExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>(), new ThreadPoolExecutor.DiscardPolicy());
-        mainExecutor = appContext.getMainExecutor();
-        tor = new AndroidTorWrapper(appContext, wakeLockManager, ioExecutor, mainExecutor, architecture(), appContext.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
+        mainExecutor = command -> new Handler(Looper.getMainLooper()).post(command);
+        tor = new AndroidTorWrapper(application, wakeLockManager, ioExecutor, mainExecutor, architecture(), application.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
         tor.setObserver(this);
     }
 
@@ -65,19 +68,20 @@ public final class TorController implements TorWrapper.Observer {
     }
 
     public static void configureWebViewProxyForUrl(@NonNull Context context, String url, @NonNull Runnable afterProxy) {
+        TorController controller = get(context);
         if (!isOnionUrl(url) || !WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
             if (WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
-                ProxyController.getInstance().clearProxyOverride(context.getMainExecutor(), afterProxy);
+                ProxyController.getInstance().clearProxyOverride(controller.mainExecutor, afterProxy);
             } else {
                 afterProxy.run();
             }
             return;
         }
-        get(context).start(() -> {
+        controller.start(() -> {
             ProxyConfig config = new ProxyConfig.Builder()
                     .addProxyRule("socks://127.0.0.1:" + SOCKS_PORT, ProxyConfig.MATCH_ALL_SCHEMES)
                     .build();
-            ProxyController.getInstance().setProxyOverride(config, context.getMainExecutor(), afterProxy);
+            ProxyController.getInstance().setProxyOverride(config, controller.mainExecutor, afterProxy);
         });
     }
 
@@ -128,7 +132,7 @@ public final class TorController implements TorWrapper.Observer {
         if (instance == null) return;
         try { instance.tor.stop(); } catch (Exception ignored) { }
         if (WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
-            ProxyController.getInstance().clearProxyOverride(context.getMainExecutor(), () -> { });
+            ProxyController.getInstance().clearProxyOverride(instance.mainExecutor, () -> { });
         }
         instance.executor.shutdownNow();
         instance = null;


### PR DESCRIPTION
## Problema

O workflow de release falha na etapa `./gradlew clean test --no-build-cache --rerun-tasks` ao compilar `TorController.java`.

O erro real do pipeline é:

- `AndroidWakeLockManagerFactory.createAndroidWakeLockManager(appContext)` recebe `Context`, mas a API exige `Application`.
- `new AndroidTorWrapper(appContext, ...)` também exige `Application`.

## Correção

- Converter o application context para `Application` uma única vez no construtor.
- Passar `Application` para `AndroidWakeLockManagerFactory` e `AndroidTorWrapper`.
- Substituir `Context.getMainExecutor()` por um executor baseado em `Handler(Looper.getMainLooper())`, mantendo compatibilidade com o `minSdkVersion 21`.
- Reutilizar esse executor nas operações de proxy do WebView e no shutdown.

## Validação

O pipeline que motivou esta PR é o workflow manual `34275106118`, executado no commit `70eb4ee62bdd97763437209ffd857f91ac378b7f`. A falha ocorre em quatro variantes (`TvDebug`, `MobileRelease`, `MobileDebug` e `TvRelease`) com os mesmos dois erros de tipo em `TorController.java`.

Esta PR corrige especificamente esses erros de compilação sem duplicar as alterações já presentes na PR #91.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when configuring the WebView proxy and shutting down Tor-related services.
  * Improved coordination of application tasks on Android’s main thread, helping ensure smoother startup and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->