### PR TITLE
fix: WebView QR, About scrolling, Onion Service and settings UI for 10.1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
-        versionCode 23
-        versionName "10.1.0"
+        versionCode 24
+        versionName "10.1.1"
         applicationVariants.all { variant ->
             variant.outputs.all {
                 outputFileName = "Drop-Android.apk"
@@ -81,13 +81,9 @@ android {
     def resolveSigningValue = { List<String> propertyNames, String envName ->
         for (propertyName in propertyNames) {
             def propertyValue = project.findProperty(propertyName)
-            if (propertyValue != null && !propertyValue.toString().trim().isEmpty()) {
-                return propertyValue.toString().trim()
-            }
+            if (propertyValue != null && !propertyValue.toString().trim().isEmpty()) return propertyValue.toString().trim()
             def fileValue = keystoreProperties.getProperty(propertyName)
-            if (fileValue != null && !fileValue.trim().isEmpty()) {
-                return fileValue.trim()
-            }
+            if (fileValue != null && !fileValue.trim().isEmpty()) return fileValue.trim()
         }
         def envValue = System.getenv(envName)
         return envValue != null ? envValue.toString().trim() : null
@@ -148,7 +144,6 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    // 1.15.0 requires minSdk 23; 1.14.0 is the newest stable WebKit release that keeps API 21 support.
     implementation 'androidx.webkit:webkit:1.14.0'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'org.jsoup:jsoup:1.18.1'

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -1,5 +1,7 @@
 package com.erikraft.drop;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -9,9 +11,12 @@ import android.os.Vibrator;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.JavascriptInterface;
 
 import androidx.documentfile.provider.DocumentFile;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.anggrayudi.storage.FileWrapper;
 import com.anggrayudi.storage.extension.IOUtils;
@@ -46,9 +51,7 @@ public class JavaScriptInterface {
     public synchronized void newFile(final String fileName, final String mimeType, final String fileSize) throws IOException {
         Log.i("DropAndroidJS", "Transfer Start: Receiving file. fileName=" + fileName + ", mimeType=" + mimeType + ", fileSize=" + fileSize);
         String finalMime = mimeType;
-        if (mimeType.startsWith("base64:")) {
-            finalMime = mimeType.substring(7);
-        }
+        if (mimeType.startsWith("base64:")) finalMime = mimeType.substring(7);
 
         IOUtils.closeStreamQuietly(fileOutputStream);
         fileOutputStream = null;
@@ -58,15 +61,9 @@ public class JavaScriptInterface {
         transferActive = false;
 
         final FileWrapper fileWrapper = createFileWrapper(fileName, finalMime);
-        if (fileWrapper == null) {
-            Log.e("DropAndroidJS", "Transfer Failure: Missing storage permissions for " + fileName);
-            throw new IOException("Missing storage permissions");
-        }
+        if (fileWrapper == null) throw new IOException("Missing storage permissions");
         fileOutputStream = UriUtils.openOutputStream(fileWrapper.getUri(), context.getApplicationContext());
-        if (fileOutputStream == null) {
-            Log.e("DropAndroidJS", "Transfer Failure: Cannot write target file: " + fileWrapper.getUri());
-            throw new IOException("Cannot write target file");
-        }
+        if (fileOutputStream == null) throw new IOException("Cannot write target file");
         fileHeader = new FileHeader(fileName, finalMime, fileSize, fileWrapper);
         try {
             messageDigest = java.security.MessageDigest.getInstance("SHA-256");
@@ -76,9 +73,7 @@ public class JavaScriptInterface {
     }
 
     private long parseExpectedBytes(final String fileSize) {
-        if (TextUtils.isEmpty(fileSize)) {
-            return -1;
-        }
+        if (TextUtils.isEmpty(fileSize)) return -1;
         try {
             return Long.parseLong(fileSize.trim());
         } catch (NumberFormatException e) {
@@ -91,111 +86,67 @@ public class JavaScriptInterface {
         if (Build.VERSION.SDK_INT > 28) {
             final DocumentFile saveLocation = MainActivity.getSaveLocation();
             if (saveLocation != null) {
-                final DocumentFile file = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(),
-                        fileName, mimeType);
-                if (file != null) {
-                    return new FileWrapper.Document(file);
-                }
+                final DocumentFile file = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(), fileName, mimeType);
+                if (file != null) return new FileWrapper.Document(file);
             }
             final FileDescription description = new FileDescription(fileName, "", mimeType);
-            return DocumentFileCompat.createDownloadWithMediaStoreFallback(context.getApplicationContext(),
-                    description);
-        } else {
-            final String[] nameSplit = fileName.split("\\.");
-            while (nameSplit[0].length() < 3) {
-                nameSplit[0] += nameSplit[0];
-            }
-            final DocumentFile file = DocumentFile.fromFile(
-                    File.createTempFile(nameSplit[0], "." + nameSplit[nameSplit.length - 1], context.getCacheDir()));
-            return new FileWrapper.Document(file);
+            return DocumentFileCompat.createDownloadWithMediaStoreFallback(context.getApplicationContext(), description);
         }
+        final String[] nameSplit = fileName.split("\\.");
+        while (nameSplit[0].length() < 3) nameSplit[0] += nameSplit[0];
+        final DocumentFile file = DocumentFile.fromFile(File.createTempFile(nameSplit[0], "." + nameSplit[nameSplit.length - 1], context.getCacheDir()));
+        return new FileWrapper.Document(file);
     }
 
     @JavascriptInterface
     public void downloadBase64File(final String requestedName, final String requestedMime, final String base64Data) {
-        if (base64Data == null || base64Data.isEmpty()) {
-            Log.w("DropAndroidJS", "Web download ignored: empty payload");
-            return;
-        }
-
+        if (base64Data == null || base64Data.isEmpty()) return;
         final String name = sanitizeDownloadName(requestedName);
         final String mime = TextUtils.isEmpty(requestedMime) ? "application/octet-stream" : requestedMime;
-
         try {
             final byte[] bytes = Base64.decode(base64Data, Base64.DEFAULT);
             final DocumentFile saveLocation = MainActivity.getSaveLocation();
-            if (saveLocation == null) {
-                throw new IOException("Unable to access Android Downloads location");
-            }
-
-            final DocumentFile target = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(),
-                    name, mime);
-            if (target == null) {
-                throw new IOException("Unable to create Android download file");
-            }
-
+            if (saveLocation == null) throw new IOException("Unable to access Android Downloads location");
+            final DocumentFile target = DocumentFileUtils.makeFile(saveLocation, context.getApplicationContext(), name, mime);
+            if (target == null) throw new IOException("Unable to create Android download file");
             final OutputStream outputStream = UriUtils.openOutputStream(target.getUri(), context.getApplicationContext());
-            if (outputStream == null) {
-                throw new IOException("Unable to open Android download file");
-            }
-
+            if (outputStream == null) throw new IOException("Unable to open Android download file");
             try {
                 outputStream.write(bytes);
                 outputStream.flush();
             } finally {
                 IOUtils.closeStreamQuietly(outputStream);
             }
-
-            Log.i("DropAndroidJS", "Web download saved: " + name + " (" + bytes.length + " bytes)");
-            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
-                    "Baixado: " + name, android.widget.Toast.LENGTH_LONG).show());
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context, "Baixado: " + name, android.widget.Toast.LENGTH_LONG).show());
         } catch (Exception e) {
             Log.e("DropAndroidJS", "Web download failed: " + name, e);
-            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
-                    "Falha ao baixar " + name, android.widget.Toast.LENGTH_LONG).show());
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context, "Falha ao baixar " + name, android.widget.Toast.LENGTH_LONG).show());
         }
     }
 
     private String sanitizeDownloadName(final String requestedName) {
         String name = TextUtils.isEmpty(requestedName) ? "download" : requestedName;
         name = name.replace('\\', '_').replace('/', '_').replace('\n', '_').replace('\r', '_');
-        if (name.equals(".") || name.equals("..")) {
-            return "download";
-        }
-        return name;
+        return name.equals(".") || name.equals("..") ? "download" : name;
     }
 
-    /**
-     * Writes each binary WebRTC chunk exactly once. The synchronized bridge prevents
-     * concurrent JavaScript-interface calls from interleaving writes to the same stream.
-     */
     @JavascriptInterface
     public synchronized void onBytes(final String dec) throws IOException {
-        if (fileOutputStream == null || fileHeader == null || !transferActive && totalBytesReceived > 0) {
-            Log.e("DropAndroidJS", "Transfer Failure: no active file stream during onBytes");
-            return;
-        }
+        if (fileOutputStream == null || fileHeader == null || !transferActive && totalBytesReceived > 0) return;
         try {
             final byte[] bytes = Base64.decode(dec, Base64.NO_WRAP);
             fileOutputStream.write(bytes);
-            if (messageDigest != null) {
-                messageDigest.update(bytes);
-            }
+            if (messageDigest != null) messageDigest.update(bytes);
             totalBytesReceived += bytes.length;
             transferActive = true;
         } catch (Exception e) {
-            Log.e("DropAndroidJS", "Transfer Failure: Exception during write of file bytes", e);
             throw new IOException("Failed to process bytes", e);
         }
     }
 
     @JavascriptInterface
     public synchronized void saveDownloadFileName(final String name, final String size) throws IOException {
-        if (fileOutputStream == null || fileHeader == null) {
-            Log.e("DropAndroidJS", "Transfer Failure: completion received without an active file");
-            return;
-        }
-
+        if (fileOutputStream == null || fileHeader == null) return;
         final long completedExpectedBytes = parseExpectedBytes(size);
         final long expected = completedExpectedBytes >= 0 ? completedExpectedBytes : expectedBytes;
         final boolean sizeMatches = expected < 0 || expected == totalBytesReceived;
@@ -204,18 +155,13 @@ public class JavaScriptInterface {
         if (messageDigest != null) {
             final byte[] hash = messageDigest.digest();
             final StringBuilder sb = new StringBuilder();
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b));
-            }
+            for (byte b : hash) sb.append(String.format("%02x", b));
             sha256Hex = sb.toString();
         }
 
         try {
             fileOutputStream.flush();
             fileOutputStream.close();
-        } catch (IOException e) {
-            Log.e("DropAndroidJS", "Transfer Failure: Exception during flush/close of file output stream", e);
-            throw e;
         } finally {
             fileOutputStream = null;
             messageDigest = null;
@@ -223,23 +169,15 @@ public class JavaScriptInterface {
         }
 
         if (!sizeMatches) {
-            Log.e("DropAndroidJS", "Transfer Failure: Size mismatch for " + name
-                    + " (Expected: " + expected + ", Received: " + totalBytesReceived
-                    + ", SHA-256: " + sha256Hex + ")");
-            if (fileHeader.file.delete()) {
-                Log.w("DropAndroidJS", "Corrupted/incomplete file deleted: " + name);
-            }
+            Log.e("DropAndroidJS", "Transfer Failure: Size mismatch for " + name + " (Expected: " + expected + ", Received: " + totalBytesReceived + ", SHA-256: " + sha256Hex + ")");
+            if (fileHeader.file.delete()) Log.w("DropAndroidJS", "Corrupted/incomplete file deleted: " + name);
             fileHeader = null;
             expectedBytes = -1;
             totalBytesReceived = 0;
-            context.runOnUiThread(() -> android.widget.Toast.makeText(context,
-                    "Transferência incompleta: " + name, android.widget.Toast.LENGTH_LONG).show());
+            context.runOnUiThread(() -> android.widget.Toast.makeText(context, "Transferência incompleta: " + name, android.widget.Toast.LENGTH_LONG).show());
             return;
         }
 
-        Log.i("DropAndroidJS", "Transfer Complete: Saved file " + name
-                + " (Expected Size: " + expected + ", Bytes Received: " + totalBytesReceived
-                + ", SHA-256: " + sha256Hex + ", Integrity: Size OK)");
         context.downloadFilesList.add(fileHeader);
         fileHeader = null;
         expectedBytes = -1;
@@ -247,20 +185,63 @@ public class JavaScriptInterface {
     }
 
     public static String getSendTextDialogWithPreInsertedString(final String text) {
-        return "javascript: " +
-                "try {" +
-                "    document.getElementById(\"textInput\").innerHTML=\""
-                + TextUtils.htmlEncode(text).replaceAll("\\n", "<br />") + "\";" +
-                "    console.log(\"successfully set pre-inserted text (snapdrop based)\");" +
-                "} catch (e) {" +
-                "    console.error(\"Error setting pre-inserted text (snapdrop based): \" + e);" +
-                "}" +
-                "Events.fire('activate-share-mode', {text: SnapdropAndroid.getTextFromUploadIntent()});";
+        return "javascript: try { document.getElementById(\"textInput\").innerHTML=\""
+                + TextUtils.htmlEncode(text).replaceAll("\\n", "<br />") + "\";"
+                + " Events.fire('activate-share-mode', {text: SnapdropAndroid.getTextFromUploadIntent()}); } catch (e) { console.error(e); }";
     }
 
     @JavascriptInterface
     public void copyToClipboard(final String text) {
         ClipboardUtils.copy(context, text);
+    }
+
+    /** Returns the current Android clipboard text to the WebView without leaving the WebView UI. */
+    @JavascriptInterface
+    public String getClipboardText() {
+        final ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard == null || !clipboard.hasPrimaryClip()) return "";
+        final ClipData data = clipboard.getPrimaryClip();
+        if (data == null || data.getItemCount() == 0) return "";
+        final CharSequence text = data.getItemAt(0).coerceToText(context);
+        return text == null ? "" : text.toString();
+    }
+
+    /** Keeps the Android window awake for WebView features such as Animated QR. */
+    @JavascriptInterface
+    public void setKeepScreenOn(final boolean keepOn) {
+        context.runOnUiThread(() -> {
+            if (keepOn) context.getWindow().addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            else if (!context.transfer.get()) context.getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        });
+    }
+
+    /** Disables the native pull-to-refresh container while an in-WebView overlay is being scrolled. */
+    @JavascriptInterface
+    public void setDialogVisible(final boolean visible) {
+        context.setDialogVisible(visible);
+        context.runOnUiThread(() -> setSwipeRefreshEnabled(!visible));
+    }
+
+    private void setSwipeRefreshEnabled(final boolean enabled) {
+        final View root = context.getWindow().getDecorView();
+        final ListHolder holder = new ListHolder();
+        findSwipeRefreshLayouts(root, holder);
+        for (SwipeRefreshLayout swipe : holder.items) {
+            swipe.setRefreshing(false);
+            swipe.setEnabled(enabled);
+        }
+    }
+
+    private void findSwipeRefreshLayouts(final View view, final ListHolder holder) {
+        if (view instanceof SwipeRefreshLayout) holder.items.add((SwipeRefreshLayout) view);
+        if (view instanceof ViewGroup) {
+            final ViewGroup group = (ViewGroup) view;
+            for (int i = 0; i < group.getChildCount(); i++) findSwipeRefreshLayouts(group.getChildAt(i), holder);
+        }
+    }
+
+    private static final class ListHolder {
+        final java.util.ArrayList<SwipeRefreshLayout> items = new java.util.ArrayList<>();
     }
 
     @JavascriptInterface
@@ -269,54 +250,37 @@ public class JavaScriptInterface {
     }
 
     @JavascriptInterface
-    public int getVersionId() {
-        return BuildConfig.VERSION_CODE;
-    }
+    public int getVersionId() { return BuildConfig.VERSION_CODE; }
 
     @JavascriptInterface
-    public String getTextFromUploadIntent() {
-        return context.getTextFromUploadIntent();
-    }
+    public String getTextFromUploadIntent() { return context.getTextFromUploadIntent(); }
 
     @JavascriptInterface
-    public boolean shouldOpenSendTextDialog() {
-        return context.onlyText;
-    }
+    public boolean shouldOpenSendTextDialog() { return context.onlyText; }
 
     @JavascriptInterface
-    public void dialogShown() {
-        context.setDialogVisible(true);
-    }
+    public void dialogShown() { setDialogVisible(true); }
 
     @JavascriptInterface
-    public void dialogHidden() {
-        context.setDialogVisible(false);
-    }
+    public void dialogHidden() { setDialogVisible(false); }
 
     @JavascriptInterface
     public synchronized void ignoreClickedListener() {
-        Log.i("DropAndroidJS", "Transfer Canceled: Ignore clicked by user.");
         IOUtils.closeStreamQuietly(fileOutputStream);
         fileOutputStream = null;
         messageDigest = null;
         transferActive = false;
         expectedBytes = -1;
         totalBytesReceived = 0;
-        if (fileHeader != null && fileHeader.file.delete()) {
-            Log.d("ignoreClickListener", "File was deleted from SAF database");
-        } else {
-            Log.d("ignoreClickListener",
-                    "Ignore was clicked, however we haven't recognized that a file was downloaded at all");
-        }
+        if (fileHeader != null && fileHeader.file.delete()) Log.d("ignoreClickListener", "File was deleted from SAF database");
         fileHeader = null;
     }
 
     @JavascriptInterface
     public void setProgress(final float progress) {
         Log.d("DropAndroidJS", "Transfer Progress: " + progress);
-        if (progress > 0) {
-            context.transfer.set(true);
-        } else {
+        if (progress > 0) context.transfer.set(true);
+        else {
             context.transfer.set(false);
             context.forceRefresh = false;
         }
@@ -328,21 +292,14 @@ public class JavaScriptInterface {
         if (audioManager.getRingerMode() != AudioManager.RINGER_MODE_SILENT) {
             final Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
             if (vibrator.hasVibrator()) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    final VibrationEffect effect = VibrationEffect.createOneShot(500,
-                            VibrationEffect.DEFAULT_AMPLITUDE);
-                    vibrator.vibrate(effect);
-                } else {
-                    vibrator.vibrate(500);
-                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) vibrator.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE));
+                else vibrator.vibrate(500);
             }
         }
     }
 
     @JavascriptInterface
-    public void resetUploadIntent() {
-        context.resetUploadIntent();
-    }
+    public void resetUploadIntent() { context.resetUploadIntent(); }
 
     public static class FileHeader {
         private final String name;
@@ -357,42 +314,22 @@ public class JavaScriptInterface {
             this.file = file;
         }
 
-        public String getName() {
-            return name;
-        }
-
-        public String getMime() {
-            return mime;
-        }
-
-        public String getSize() {
-            return size;
-        }
-
-        public Uri getFileUri() {
-            return file.getUri();
-        }
+        public String getName() { return name; }
+        public String getMime() { return mime; }
+        public String getSize() { return size; }
+        public Uri getFileUri() { return file.getUri(); }
 
         @Override
         public String toString() {
-            return "FileHeader{" +
-                    "name='" + name + '\'' +
-                    ", mime='" + mime + '\'' +
-                    ", size='" + size + '\'' +
-                    '}';
+            return "FileHeader{" + "name='" + name + '\'' + ", mime='" + mime + '\'' + ", size='" + size + '\'' + '}';
         }
     }
 
     public static String getAssetsJS(final Context context, final String fileName) {
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(context.getAssets().open(fileName), StandardCharsets.UTF_8))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(fileName), StandardCharsets.UTF_8))) {
             final StringBuilder text = new StringBuilder("javascript:");
             String currentLine;
-            while ((currentLine = reader.readLine()) != null) {
-                if (!currentLine.trim().startsWith("//")) {
-                    text.append(currentLine);
-                }
-            }
+            while ((currentLine = reader.readLine()) != null) if (!currentLine.trim().startsWith("//")) text.append(currentLine);
             return text.toString();
         } catch (IOException e) {
             Log.e("JavaScriptInterface", "unable to read assets file '" + fileName + "'", e);

--- a/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
+++ b/app/src/main/java/com/erikraft/drop/OnboardingFragment2.java
@@ -38,7 +38,6 @@ public class OnboardingFragment2 extends Fragment {
             this.description = description;
             this.warning = warning;
         }
-
     }
 
     public static class ServerItemViewHolder extends RecyclerView.ViewHolder {
@@ -63,7 +62,6 @@ public class OnboardingFragment2 extends Fragment {
     }
 
     public class ServerItemCardAdapter extends RecyclerView.Adapter<ServerItemViewHolder> {
-
         private final List<ServerItem> items;
 
         public ServerItemCardAdapter(final List<ServerItem> items) {
@@ -73,24 +71,15 @@ public class OnboardingFragment2 extends Fragment {
         @NonNull
         @Override
         public ServerItemViewHolder onCreateViewHolder(final @NonNull ViewGroup parent, final int viewType) {
-            final View view = LayoutInflater.from(parent.getContext())
-                    .inflate(R.layout.servercard, parent, false);
-
+            final View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.servercard, parent, false);
             final ServerItemViewHolder holder = new ServerItemViewHolder(view);
-
-            holder.itemView.setOnClickListener(v -> {
-                tempUrl.setValue(holder.urlTextView.getText().toString());
-            });
-
+            holder.itemView.setOnClickListener(v -> tempUrl.setValue(holder.urlTextView.getText().toString()));
             holder.itemView.setOnLongClickListener(v -> {
                 removeServer(holder.urlTextView.getText().toString());
                 return true;
             });
-
-            tempUrl.observe(requireActivity(), url -> {
-                ((MaterialCardView) holder.itemView).setChecked(holder.urlTextView.getText().toString().equals(url));
-            });
-
+            tempUrl.observe(requireActivity(), url -> ((MaterialCardView) holder.itemView)
+                    .setChecked(holder.urlTextView.getText().toString().equals(url)));
             return holder;
         }
 
@@ -107,7 +96,6 @@ public class OnboardingFragment2 extends Fragment {
     }
 
     final MutableLiveData<String> tempUrl = new MutableLiveData<>();
-
     FragmentOnboarding2Binding binding;
     SharedPreferences pref;
 
@@ -117,85 +105,59 @@ public class OnboardingFragment2 extends Fragment {
 
     @Override
     public void onViewCreated(final @NonNull View view, final Bundle savedInstanceState) {
-
         final OnboardingViewModel viewModel = new ViewModelProvider(requireActivity()).get(OnboardingViewModel.class);
-
         binding = FragmentOnboarding2Binding.bind(view);
         pref = PreferenceManager.getDefaultSharedPreferences(requireContext());
         tempUrl.setValue(pref.getString(getString(R.string.pref_baseurl), "https://drop.erikraft.com/"));
-
         reloadServerList();
 
-        binding.add.setOnClickListener(v -> ViewUtils.showEditTextWithResetPossibility(this, "Custom URL", null, null, Link.bind("https://github.com/erikraft/Drop/blob/master/docs/FAQ.md", R.string.baseurl_unofficial_instances), url -> {
-            if (url == null) {
-                return;
-            }
-
-            if (isSnapdropNet(url)) {
-                showSnapdropUpdateNotice();
-                return;
-            }
-
-            if (url.startsWith("!!")) {
-                newServer(url.substring("!!".length()));
-            } else if (url.toLowerCase().contains(".onion")) {
-                String onionUrl = url.contains("://") ? url : "http://" + url;
-                if (!onionUrl.endsWith("/")) onionUrl += "/";
-                newServer(onionUrl);
-            } else if (url.toLowerCase().contains(".onion")) {
-                String onionUrl = url.contains("://") ? url : "http://" + url;
-                if (!onionUrl.endsWith("/")) onionUrl += "/";
-                newServer(onionUrl);
-            } else if (url.startsWith("http")) {
-                NetworkUtils.checkInstance(this, url, result -> {
-                    if (result) {
-                        newServer(url);
+        binding.add.setOnClickListener(v -> ViewUtils.showEditTextWithResetPossibility(this, "Custom URL", null, null,
+                Link.bind("https://github.com/erikraft/Drop/blob/master/docs/FAQ.md", R.string.baseurl_unofficial_instances), url -> {
+                    if (url == null) return;
+                    if (isSnapdropNet(url)) {
+                        showSnapdropUpdateNotice();
+                        return;
                     }
-                });
-            } else {
-                String mightBeHttpsUrl = "https://" + url;
-                NetworkUtils.checkInstance(this, mightBeHttpsUrl, resultHttps -> {
-                    if (resultHttps) {
-                        newServer(mightBeHttpsUrl);
+                    if (url.startsWith("!!")) {
+                        newServer(url.substring("!!".length()));
+                    } else if (url.toLowerCase().contains(".onion")) {
+                        String onionUrl = url.contains("://") ? url : "http://" + url;
+                        if (!onionUrl.endsWith("/")) onionUrl += "/";
+                        newServer(onionUrl);
+                    } else if (url.startsWith("http")) {
+                        NetworkUtils.checkInstance(this, url, result -> {
+                            if (result) newServer(url);
+                        });
                     } else {
-                        String mightBeHttpUrl = "http://" + url;
-                        NetworkUtils.checkInstance(this, mightBeHttpUrl, resultHttp -> {
-                            if (resultHttp) {
-                                newServer(mightBeHttpUrl);
+                        String mightBeHttpsUrl = "https://" + url;
+                        NetworkUtils.checkInstance(this, mightBeHttpsUrl, resultHttps -> {
+                            if (resultHttps) {
+                                newServer(mightBeHttpsUrl);
+                            } else {
+                                String mightBeHttpUrl = "http://" + url;
+                                NetworkUtils.checkInstance(this, mightBeHttpUrl, resultHttp -> {
+                                    if (resultHttp) newServer(mightBeHttpUrl);
+                                });
                             }
                         });
                     }
-                });
-            }
-        }));
+                }));
 
         binding.continueButton.setOnClickListener(v -> {
             viewModel.url(tempUrl.getValue());
-            if (viewModel.isOnlyServerSelection()) {
-                requireActivity().finish();
-            } else {
-                viewModel.launchFragment(OnboardingFragment3.class);
-            }
+            if (viewModel.isOnlyServerSelection()) requireActivity().finish();
+            else viewModel.launchFragment(OnboardingFragment3.class);
         });
         binding.continueButton.requestFocus();
     }
 
     private boolean isSnapdropNet(final String value) {
-        if (value == null) {
-            return false;
-        }
-
+        if (value == null) return false;
         String normalized = value.trim();
-        if (normalized.startsWith("!!")) {
-            normalized = normalized.substring(2).trim();
-        }
-        if (!normalized.contains("://")) {
-            normalized = "https://" + normalized;
-        }
+        if (normalized.startsWith("!!")) normalized = normalized.substring(2).trim();
+        if (!normalized.contains("://")) normalized = "https://" + normalized;
         normalized = normalized.replaceFirst("^http://", "https://");
-        while (normalized.endsWith("/")) {
-            normalized = normalized.substring(0, normalized.length() - 1);
-        }
+        while (normalized.endsWith("/")) normalized = normalized.substring(0, normalized.length() - 1);
         return "https://snapdrop.net".equalsIgnoreCase(normalized)
                 || "https://www.snapdrop.net".equalsIgnoreCase(normalized);
     }
@@ -204,29 +166,25 @@ public class OnboardingFragment2 extends Fragment {
         new MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.important_update_title)
                 .setMessage(R.string.important_update_message)
-                .setPositiveButton(R.string.important_update_ok, (dialog, which) ->
-                        tempUrl.setValue("https://drop.erikraft.com/"))
+                .setPositiveButton(R.string.important_update_ok, (dialog, which) -> tempUrl.setValue("https://drop.erikraft.com/"))
                 .show();
     }
 
     private void reloadServerList() {
         final Set<String> serverUrls = pref.getStringSet(getString(R.string.pref_custom_servers), new HashSet<>());
-
-        // Keep official ErikrafT instances in a deterministic priority order.
-        // PairDrop remains available only as the fourth/final fallback.
         final List<ServerItem> servers = new ArrayList<>();
+
         servers.add(new ServerItem("https://drop.erikraft.com/", getString(R.string.onboarding_server_primary_summary), null));
         servers.add(new ServerItem("https://drop-fallback.erikraft.com/", getString(R.string.onboarding_server_secondary_summary), null));
         servers.add(new ServerItem("https://dropfallback.erikraft.com/", getString(R.string.onboarding_server_tertiary_summary), null));
-        servers.add(new ServerItem("http://nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion/", "ErikrafT Drop™ Onion Service (Beta)", "Requer Tor. O PairDrop fica como quinto servidor."));
-        servers.add(new ServerItem("http://nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion/", "ErikrafT Drop™ Onion Service (Beta)", "Requer Tor. O PairDrop fica como quinto servidor."));
-        servers.add(new ServerItem("https://pairdrop.net/", getString(R.string.onboarding_server_quaternary_summary), null));
+        servers.add(new ServerItem("http://nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion/",
+                getString(R.string.onboarding_server_quaternary_summary), getString(R.string.onboarding_server_onion_warning)));
+        servers.add(new ServerItem("https://pairdrop.net/", getString(R.string.onboarding_server_quinary_summary), null));
 
         for (String url : serverUrls) {
             if (!url.equals("https://drop.erikraft.com/")
                     && !url.equals("https://drop-fallback.erikraft.com/")
                     && !url.equals("https://dropfallback.erikraft.com/")
-                    && !url.equals("http://nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion/")
                     && !url.equals("http://nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion/")
                     && !url.equals("https://pairdrop.net/")
                     && !url.equals("https://pairdrop.net")) {
@@ -251,5 +209,4 @@ public class OnboardingFragment2 extends Fragment {
         pref.edit().putStringSet(getString(R.string.pref_custom_servers), serverUrls).apply();
         reloadServerList();
     }
-
 }

--- a/app/src/main/java/com/erikraft/drop/OnionTransferActivity.java
+++ b/app/src/main/java/com/erikraft/drop/OnionTransferActivity.java
@@ -7,10 +7,15 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.ViewGroup;
-import android.widget.Button;
+import android.os.Handler;
+import android.os.Looper;
+import android.text.InputType;
+import android.view.MenuItem;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -18,6 +23,11 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.card.MaterialCardView;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.common.BitMatrix;
@@ -28,75 +38,286 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Beta Android-only Onion Share mode. Files stay on-device; Tor exposes the local HTTP server. */
+/** Android-only Onion Service sharing mode. Files and text are served from the device through Tor. */
 public class OnionTransferActivity extends AppCompatActivity {
     private final List<File> files = new ArrayList<>();
     private ActivityResultLauncher<Intent> picker;
     private OnionHttpServer server;
     private TextView status;
     private TextView address;
+    private TextView selectionSummary;
+    private ProgressBar progress;
     private ImageView qr;
+    private TextInputEditText textInput;
+    private MaterialButton startButton;
+    private MaterialButton stopButton;
+    private MaterialButton copyButton;
+    private MaterialButton shareButton;
+    private String textToShare = "";
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private Runnable startupTimeout;
 
-    @Override protected void onCreate(Bundle savedInstanceState) {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle("Transferência via Onion (Beta)");
-        LinearLayout root = new LinearLayout(this); root.setOrientation(LinearLayout.VERTICAL); root.setPadding(28, 28, 28, 28);
-        TextView title = new TextView(this); title.setText("Transferência via Onion"); title.setTextSize(24); root.addView(title);
-        TextView help = new TextView(this); help.setText("O Android inicia Tor, cria um Onion Service temporário e compartilha um endereço .onion. O conteúdo não passa pelo Render/Vercel."); root.addView(help);
-        Button pick = new Button(this); pick.setText("Selecionar arquivos"); root.addView(pick);
-        status = new TextView(this); status.setText("Nenhum arquivo selecionado."); root.addView(status);
-        Button start = new Button(this); start.setText("Iniciar Onion Service"); root.addView(start);
-        address = new TextView(this); address.setTextIsSelectable(true); address.setTextSize(16); root.addView(address);
-        qr = new ImageView(this); root.addView(qr, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 420));
-        Button copy = new Button(this); copy.setText("Copiar link"); root.addView(copy);
-        Button share = new Button(this); share.setText("Compartilhar"); root.addView(share);
+        SnapdropApplication.setAppTheme(this);
+        buildUi();
+        registerPicker();
+    }
+
+    private void buildUi() {
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+
+        MaterialToolbar toolbar = new MaterialToolbar(this);
+        toolbar.setTitle(getString(R.string.onion_transfer_title));
+        toolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material);
+        toolbar.setNavigationOnClickListener(v -> finish());
+        root.addView(toolbar, new LinearLayout.LayoutParams(-1, getResources().getDimensionPixelSize(com.google.android.material.R.dimen.mtrl_toolbar_default_height)));
+        setSupportActionBar(toolbar);
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.setFillViewport(true);
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int pad = dp(20);
+        content.setPadding(pad, dp(12), pad, dp(28));
+
+        TextView title = text(getString(R.string.onion_transfer_title), 26);
+        content.addView(title);
+        TextView description = text(getString(R.string.onion_transfer_description), 15);
+        description.setPadding(0, dp(8), 0, dp(16));
+        content.addView(description);
+
+        MaterialCardView shareCard = card();
+        LinearLayout shareContent = verticalInsideCard(shareCard);
+        TextView shareTitle = text("Conteúdo para compartilhar", 18);
+        shareContent.addView(shareTitle);
+
+        MaterialButton pick = button(getString(R.string.onion_transfer_select_files));
+        shareContent.addView(pick);
+        selectionSummary = text("Nenhum arquivo selecionado.", 14);
+        shareContent.addView(selectionSummary);
+
+        TextInputLayout textLayout = new TextInputLayout(this);
+        textLayout.setHint(getString(R.string.onion_transfer_send_text));
+        textInput = new TextInputEditText(this);
+        textInput.setHint(getString(R.string.onion_transfer_text_hint));
+        textInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        textInput.setMinLines(4);
+        textInput.setGravity(android.view.Gravity.TOP | android.view.Gravity.START);
+        textLayout.addView(textInput, new LinearLayout.LayoutParams(-1, -2));
+        shareContent.addView(textLayout, lpTop(dp(14)));
+
+        MaterialButton useText = button(getString(R.string.onion_transfer_send_text));
+        useText.setOnClickListener(v -> {
+            textToShare = textInput.getText() == null ? "" : textInput.getText().toString();
+            updateSelectionSummary();
+        });
+        shareContent.addView(useText, lpTop(dp(8)));
+        content.addView(shareCard);
+
+        MaterialCardView statusCard = card();
+        LinearLayout statusContent = verticalInsideCard(statusCard);
+        status = text("Pronto para iniciar.", 15);
+        statusContent.addView(status);
+        progress = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+        progress.setMax(100);
+        progress.setProgress(0);
+        progress.setVisibility(View.GONE);
+        statusContent.addView(progress, lpTop(dp(12)));
+        content.addView(statusCard, lpTop(dp(12)));
+
+        LinearLayout actions = new LinearLayout(this);
+        actions.setOrientation(LinearLayout.HORIZONTAL);
+        actions.setWeightSum(2);
+        startButton = button(getString(R.string.onion_transfer_start));
+        stopButton = button(getString(R.string.onion_transfer_stop));
+        stopButton.setEnabled(false);
+        actions.addView(startButton, new LinearLayout.LayoutParams(0, -2, 1));
+        LinearLayout.LayoutParams stopParams = new LinearLayout.LayoutParams(0, -2, 1);
+        stopParams.setMargins(dp(8), 0, 0, 0);
+        actions.addView(stopButton, stopParams);
+        content.addView(actions, lpTop(dp(14)));
+
+        address = text("", 15);
+        address.setTextIsSelectable(true);
+        content.addView(address, lpTop(dp(14)));
+
+        qr = new ImageView(this);
+        qr.setAdjustViewBounds(true);
+        qr.setContentDescription("QR Code do Onion Service");
+        qr.setVisibility(View.GONE);
+        content.addView(qr, lpTop(dp(12)));
+
+        LinearLayout linkActions = new LinearLayout(this);
+        linkActions.setGravity(android.view.Gravity.CENTER);
+        copyButton = button(getString(R.string.onion_transfer_copy));
+        shareButton = button(getString(R.string.onion_transfer_share));
+        copyButton.setEnabled(false);
+        shareButton.setEnabled(false);
+        linkActions.addView(copyButton);
+        linkActions.addView(shareButton, lpLeft(dp(8)));
+        content.addView(linkActions, lpTop(dp(10)));
+
+        scroll.addView(content);
+        root.addView(scroll, new LinearLayout.LayoutParams(-1, 0, 1));
         setContentView(root);
 
+        pick.setOnClickListener(v -> launchPicker());
+        startButton.setOnClickListener(v -> startOnion());
+        stopButton.setOnClickListener(v -> stopOnion());
+        copyButton.setOnClickListener(v -> copyLink());
+        shareButton.setOnClickListener(v -> shareLink());
+    }
+
+    private void registerPicker() {
         picker = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             if (result.getResultCode() != RESULT_OK || result.getData() == null) return;
             files.clear();
             Intent data = result.getData();
             ClipData clip = data.getClipData();
             try {
-                if (clip != null) for (int i = 0; i < clip.getItemCount(); i++) files.add(copyToCache(clip.getItemAt(i).getUri()));
-                else if (data.getData() != null) files.add(copyToCache(data.getData()));
-                status.setText(files.size() + " arquivo(s) pronto(s) para compartilhar.");
-            } catch (IOException e) { Toast.makeText(this, "Falha ao preparar arquivo: " + e.getMessage(), Toast.LENGTH_LONG).show(); }
+                if (clip != null) {
+                    for (int i = 0; i < clip.getItemCount(); i++) files.add(copyToCache(clip.getItemAt(i).getUri()));
+                } else if (data.getData() != null) {
+                    files.add(copyToCache(data.getData()));
+                }
+                updateSelectionSummary();
+            } catch (IOException e) {
+                Toast.makeText(this, "Falha ao preparar arquivo: " + e.getMessage(), Toast.LENGTH_LONG).show();
+            }
         });
-        pick.setOnClickListener(v -> { Intent i = new Intent(Intent.ACTION_OPEN_DOCUMENT); i.setType("*/*"); i.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true); i.addCategory(Intent.CATEGORY_OPENABLE); picker.launch(i); });
-        start.setOnClickListener(v -> startOnion());
-        copy.setOnClickListener(v -> { if (address.getText().length() > 0) { ClipboardManager cm = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE); cm.setPrimaryClip(ClipData.newPlainText("ErikrafT Drop Onion", address.getText())); Toast.makeText(this, "Link copiado.", Toast.LENGTH_SHORT).show(); } });
-        share.setOnClickListener(v -> { if (address.getText().length() > 0) { Intent i = new Intent(Intent.ACTION_SEND); i.setType("text/plain"); i.putExtra(Intent.EXTRA_TEXT, address.getText().toString()); startActivity(Intent.createChooser(i, "Compartilhar Onion Service")); } });
+    }
+
+    private void launchPicker() {
+        Intent i = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        i.setType("*/*");
+        i.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        i.addCategory(Intent.CATEGORY_OPENABLE);
+        picker.launch(i);
     }
 
     private File copyToCache(Uri uri) throws IOException {
         String name = "file-" + System.currentTimeMillis();
         android.database.Cursor c = getContentResolver().query(uri, null, null, null, null);
-        if (c != null) { int n = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME); if (c.moveToFirst() && n >= 0) name = c.getString(n); c.close(); }
+        if (c != null) {
+            int n = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME);
+            if (c.moveToFirst() && n >= 0) name = c.getString(n);
+            c.close();
+        }
         File out = new File(getCacheDir(), name.replaceAll("[^a-zA-Z0-9._-]", "_"));
         try (InputStream in = getContentResolver().openInputStream(uri); java.io.FileOutputStream fos = new java.io.FileOutputStream(out)) {
             if (in == null) throw new IOException("Arquivo não pôde ser aberto");
-            byte[] buf = new byte[64 * 1024]; int len; while ((len = in.read(buf)) != -1) fos.write(buf, 0, len);
+            byte[] buf = new byte[64 * 1024];
+            int len;
+            while ((len = in.read(buf)) != -1) fos.write(buf, 0, len);
         }
         return out;
     }
 
+    private void updateSelectionSummary() {
+        if (files.isEmpty() && textToShare.isEmpty()) selectionSummary.setText(getString(R.string.onion_transfer_no_files));
+        else if (!files.isEmpty() && !textToShare.isEmpty()) selectionSummary.setText(files.size() + " arquivo(s) + texto pronto para compartilhar.");
+        else if (!files.isEmpty()) selectionSummary.setText(files.size() + " arquivo(s) pronto(s) para compartilhar.");
+        else selectionSummary.setText("Texto pronto para compartilhar.");
+    }
+
     private void startOnion() {
-        if (files.isEmpty()) { Toast.makeText(this, "Selecione pelo menos um arquivo.", Toast.LENGTH_LONG).show(); return; }
+        textToShare = textInput.getText() == null ? "" : textInput.getText().toString();
+        if (files.isEmpty() && textToShare.trim().isEmpty()) {
+            Toast.makeText(this, getString(R.string.onion_transfer_no_files), Toast.LENGTH_LONG).show();
+            return;
+        }
         try {
             if (server != null) server.stop();
-            server = new OnionHttpServer(0, files); server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
-            status.setText("Servidor local iniciado na porta " + server.getListeningPort() + ". Iniciando Tor…");
-            TorController.get(this).publishHiddenService(server.getListeningPort(), new TorController.OnionCallback() {
-                @Override public void onReady(String onion) {
-                    String link = "http://" + onion + "/"; address.setText(link); status.setText("Onion Service ativo. Compartilhe o link, QR Code ou código."); showQr(link);
+            server = new OnionHttpServer(0, files, textToShare);
+            server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+            startButton.setEnabled(false);
+            stopButton.setEnabled(true);
+            copyButton.setEnabled(false);
+            shareButton.setEnabled(false);
+            address.setText("");
+            qr.setVisibility(View.GONE);
+            progress.setVisibility(View.VISIBLE);
+            progress.setProgress(0);
+            status.setText(getString(R.string.onion_transfer_server_ready));
+
+            startupTimeout = () -> {
+                if (server != null && address.getText().length() == 0) {
+                    status.setText(getString(R.string.onion_transfer_error));
+                    Toast.makeText(this, "O Tor não respondeu a tempo. Verifique se o dispositivo permite executar o Tor.", Toast.LENGTH_LONG).show();
+                    stopOnion();
                 }
-                @Override public void onError(Exception error) { status.setText("Falha ao iniciar Onion Service: " + error.getMessage()); }
+            };
+            handler.postDelayed(startupTimeout, 120000);
+
+            TorController.get(this).publishHiddenService(server.getListeningPort(), new TorController.OnionCallback() {
+                @Override public void onProgress(int percentage) {
+                    progress.setVisibility(View.VISIBLE);
+                    progress.setProgress(percentage);
+                    status.setText(getString(R.string.onion_transfer_progress, percentage));
+                }
+
+                @Override public void onReady(String onion) {
+                    if (startupTimeout != null) handler.removeCallbacks(startupTimeout);
+                    String link = "http://" + onion + "/";
+                    address.setText(link);
+                    progress.setProgress(100);
+                    status.setText(getString(R.string.onion_transfer_ready));
+                    copyButton.setEnabled(true);
+                    shareButton.setEnabled(true);
+                    showQr(link);
+                }
+
+                @Override public void onError(Exception error) {
+                    if (startupTimeout != null) handler.removeCallbacks(startupTimeout);
+                    status.setText(getString(R.string.onion_transfer_error) + " " + (error.getMessage() == null ? "" : error.getMessage()));
+                    stopOnion();
+                }
             });
-        } catch (IOException e) { status.setText("Falha no servidor local: " + e.getMessage()); }
+        } catch (IOException e) {
+            status.setText(getString(R.string.onion_transfer_error) + " " + e.getMessage());
+        }
+    }
+
+    private void stopOnion() {
+        if (startupTimeout != null) handler.removeCallbacks(startupTimeout);
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+        TorController.shutdown(this);
+        startButton.setEnabled(true);
+        stopButton.setEnabled(false);
+        copyButton.setEnabled(false);
+        shareButton.setEnabled(false);
+        progress.setVisibility(View.GONE);
+        address.setText("");
+        qr.setVisibility(View.GONE);
+        status.setText("Serviço Onion parado.");
+    }
+
+    private void copyLink() {
+        String value = address.getText().toString().trim();
+        if (value.isEmpty()) return;
+        ClipboardManager cm = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+        if (cm != null) cm.setPrimaryClip(ClipData.newPlainText("ErikrafT Drop™ Onion", value));
+        Toast.makeText(this, "Link copiado.", Toast.LENGTH_SHORT).show();
+    }
+
+    private void shareLink() {
+        String value = address.getText().toString().trim();
+        if (value.isEmpty()) return;
+        Intent i = new Intent(Intent.ACTION_SEND);
+        i.setType("text/plain");
+        i.putExtra(Intent.EXTRA_TEXT, value);
+        startActivity(Intent.createChooser(i, getString(R.string.onion_transfer_share)));
     }
 
     private void showQr(String value) {
@@ -105,31 +326,108 @@ public class OnionTransferActivity extends AppCompatActivity {
             Bitmap bitmap = Bitmap.createBitmap(640, 640, Bitmap.Config.ARGB_8888);
             for (int x = 0; x < 640; x++) for (int y = 0; y < 640; y++) bitmap.setPixel(x, y, matrix.get(x, y) ? 0xFF000000 : 0xFFFFFFFF);
             qr.setImageBitmap(bitmap);
-        } catch (Exception e) { Toast.makeText(this, "Não foi possível gerar o QR Code.", Toast.LENGTH_SHORT).show(); }
+            qr.setVisibility(View.VISIBLE);
+        } catch (Exception e) {
+            Toast.makeText(this, "Não foi possível gerar o QR Code.", Toast.LENGTH_SHORT).show();
+        }
     }
 
-    @Override protected void onDestroy() { if (server != null) server.stop(); super.onDestroy(); }
+    @Override protected void onDestroy() {
+        if (startupTimeout != null) handler.removeCallbacks(startupTimeout);
+        if (server != null) server.stop();
+        TorController.shutdown(this);
+        super.onDestroy();
+    }
+
+    private MaterialCardView card() {
+        MaterialCardView card = new MaterialCardView(this);
+        card.setRadius(dp(18));
+        card.setCardElevation(dp(2));
+        return card;
+    }
+
+    private LinearLayout verticalInsideCard(MaterialCardView card) {
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(16), dp(16), dp(16));
+        card.addView(content);
+        return content;
+    }
+
+    private TextView text(String value, float size) {
+        TextView view = new TextView(this);
+        view.setText(value);
+        view.setTextSize(size);
+        return view;
+    }
+
+    private MaterialButton button(String label) {
+        MaterialButton button = new MaterialButton(this);
+        button.setText(label);
+        return button;
+    }
+
+    private LinearLayout.LayoutParams lpTop(int margin) {
+        LinearLayout.LayoutParams p = new LinearLayout.LayoutParams(-1, -2);
+        p.topMargin = margin;
+        return p;
+    }
+
+    private LinearLayout.LayoutParams lpLeft(int margin) {
+        LinearLayout.LayoutParams p = new LinearLayout.LayoutParams(-2, -2);
+        p.leftMargin = margin;
+        return p;
+    }
+
+    private int dp(int value) { return Math.round(value * getResources().getDisplayMetrics().density); }
 
     private static final class OnionHttpServer extends NanoHTTPD {
         private final List<File> files;
-        OnionHttpServer(int port, List<File> files) { super(port); this.files = new ArrayList<>(files); }
+        private final String text;
+
+        OnionHttpServer(int port, List<File> files, String text) {
+            super(port);
+            this.files = new ArrayList<>(files);
+            this.text = text == null ? "" : text;
+        }
+
         @Override public Response serve(IHTTPSession session) {
             String uri = session.getUri();
             if ("/".equals(uri)) {
-                StringBuilder html = new StringBuilder("<html><meta name='viewport' content='width=device-width'><body><h1>ErikrafT Drop™ Onion</h1><p>Arquivos disponíveis:</p><ul>");
-                for (int i = 0; i < files.size(); i++) { File f = files.get(i); html.append("<li><a download href='/file/").append(i).append("'>").append(escape(f.getName())).append("</a> (").append(f.length()).append(" bytes)</li>"); }
-                html.append("</ul></body></html>");
+                StringBuilder html = new StringBuilder("<!doctype html><html><meta name='viewport' content='width=device-width,initial-scale=1'><meta charset='utf-8'><title>ErikrafT Drop™ Onion</title><style>body{font-family:sans-serif;max-width:760px;margin:40px auto;padding:0 18px;line-height:1.5}a{display:block;margin:10px 0}pre{white-space:pre-wrap;background:#f4f4f4;padding:14px;border-radius:12px}</style><h1>ErikrafT Drop™</h1>");
+                if (!text.isEmpty()) html.append("<h2>Texto</h2><pre>").append(escape(text)).append("</pre>");
+                html.append("<h2>Arquivos</h2><ul>");
+                if (files.isEmpty()) html.append("<li>Nenhum arquivo.</li>");
+                for (int i = 0; i < files.size(); i++) {
+                    File f = files.get(i);
+                    html.append("<li><a download href='/file/").append(i).append("'>").append(escape(f.getName())).append("</a> (").append(f.length()).append(" bytes)</li>");
+                }
+                html.append("</ul></html>");
                 return newFixedLengthResponse(Response.Status.OK, "text/html; charset=utf-8", html.toString());
             }
             if (uri.startsWith("/file/")) {
                 try {
-                    int index = Integer.parseInt(uri.substring(6)); File f = files.get(index);
+                    int index = Integer.parseInt(uri.substring(6));
+                    File f = files.get(index);
                     return newChunkedResponse(Response.Status.OK, mime(f.getName()), new FileInputStream(f));
-                } catch (Exception e) { return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "File not found"); }
+                } catch (Exception e) {
+                    return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "File not found");
+                }
             }
             return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "Not found");
         }
-        private static String mime(String name) { String n = name.toLowerCase(); if (n.endsWith(".png")) return "image/png"; if (n.endsWith(".jpg") || n.endsWith(".jpeg")) return "image/jpeg"; if (n.endsWith(".pdf")) return "application/pdf"; return "application/octet-stream"; }
-        private static String escape(String s) { return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;"); }
+
+        private static String mime(String name) {
+            String n = name.toLowerCase();
+            if (n.endsWith(".png")) return "image/png";
+            if (n.endsWith(".jpg") || n.endsWith(".jpeg")) return "image/jpeg";
+            if (n.endsWith(".pdf")) return "application/pdf";
+            if (n.endsWith(".txt")) return "text/plain; charset=utf-8";
+            return "application/octet-stream";
+        }
+
+        private static String escape(String s) {
+            return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+        }
     }
 }

--- a/app/src/main/java/com/erikraft/drop/TorController.java
+++ b/app/src/main/java/com/erikraft/drop/TorController.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.webkit.ProxyConfig;
@@ -22,7 +23,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-/** Small Android-only Tor controller used by Onion mode and .onion WebView instances. */
+/** Android Tor controller used by Onion mode and .onion WebView instances. */
 public final class TorController implements TorWrapper.Observer {
     private static final int SOCKS_PORT = 53054;
     private static final int CONTROL_PORT = 53055;
@@ -42,7 +43,8 @@ public final class TorController implements TorWrapper.Observer {
         AndroidWakeLockManager wakeLockManager = AndroidWakeLockManagerFactory.createAndroidWakeLockManager(application);
         ThreadPoolExecutor ioExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>(), new ThreadPoolExecutor.DiscardPolicy());
         mainExecutor = command -> new Handler(Looper.getMainLooper()).post(command);
-        tor = new AndroidTorWrapper(application, wakeLockManager, ioExecutor, mainExecutor, architecture(), application.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
+        tor = new AndroidTorWrapper(application, wakeLockManager, ioExecutor, mainExecutor, architecture(),
+                application.getDir("tor", Context.MODE_PRIVATE), SOCKS_PORT, CONTROL_PORT);
         tor.setObserver(this);
     }
 
@@ -63,8 +65,12 @@ public final class TorController implements TorWrapper.Observer {
 
     public static boolean isOnionUrl(String url) {
         if (url == null) return false;
-        try { return new java.net.URI(url).getHost() != null && new java.net.URI(url).getHost().toLowerCase().endsWith(".onion"); }
-        catch (Exception e) { return url.toLowerCase().contains(".onion"); }
+        try {
+            String host = new java.net.URI(url).getHost();
+            return host != null && host.toLowerCase().endsWith(".onion");
+        } catch (Exception e) {
+            return url.toLowerCase().contains(".onion");
+        }
     }
 
     public static void configureWebViewProxyForUrl(@NonNull Context context, String url, @NonNull Runnable afterProxy) {
@@ -86,7 +92,10 @@ public final class TorController implements TorWrapper.Observer {
     }
 
     public void start(Runnable callback) {
-        if (connected) { mainExecutor.execute(callback); return; }
+        if (connected) {
+            mainExecutor.execute(callback);
+            return;
+        }
         pendingConnected = callback;
         if (started) return;
         started = true;
@@ -96,34 +105,61 @@ public final class TorController implements TorWrapper.Observer {
                 tor.enableNetwork(true);
             } catch (Exception e) {
                 started = false;
-                android.util.Log.e("ErikrafT-Tor", "Unable to start Tor", e);
+                connected = false;
+                Log.e("ErikrafT-Tor", "Unable to start Tor", e);
+                failPending(e);
             }
         });
     }
 
+    private void failPending(final Exception error) {
+        pendingConnected = null;
+        final OnionCallback callback = pendingOnion;
+        pendingOnion = null;
+        if (callback != null) mainExecutor.execute(() -> callback.onError(error));
+    }
+
     public void publishHiddenService(int localPort, OnionCallback callback) {
         pendingOnion = callback;
+        callback.onProgress(0);
         start(() -> executor.execute(() -> {
-            try { tor.publishHiddenService(localPort, 80, null); }
-            catch (Exception e) { mainExecutor.execute(() -> callback.onError(e)); }
+            try {
+                callback.onProgress(80);
+                tor.publishHiddenService(localPort, 80, null);
+            } catch (Exception e) {
+                pendingOnion = null;
+                mainExecutor.execute(() -> callback.onError(e));
+            }
         }));
     }
 
-    @Override public void onState(TorWrapper.TorState state) {
+    @Override
+    public void onState(TorWrapper.TorState state) {
         if (state == TorWrapper.TorState.CONNECTED) {
             connected = true;
-            Runnable cb = pendingConnected; pendingConnected = null;
+            Runnable cb = pendingConnected;
+            pendingConnected = null;
             if (cb != null) mainExecutor.execute(cb);
         } else if (state == TorWrapper.TorState.STOPPED) {
-            connected = false; started = false;
+            connected = false;
+            started = false;
         }
     }
 
-    @Override public void onBootstrapPercentage(int percentage) { }
+    @Override
+    public void onBootstrapPercentage(int percentage) {
+        final OnionCallback callback = pendingOnion;
+        if (callback != null) mainExecutor.execute(() -> callback.onProgress(Math.max(0, Math.min(100, percentage))));
+    }
 
-    @Override public void onHsDescriptorUpload(String onion) {
-        OnionCallback cb = pendingOnion; pendingOnion = null;
-        if (cb != null) mainExecutor.execute(() -> cb.onReady(onion));
+    @Override
+    public void onHsDescriptorUpload(String onion) {
+        OnionCallback cb = pendingOnion;
+        pendingOnion = null;
+        if (cb != null) mainExecutor.execute(() -> {
+            cb.onProgress(100);
+            cb.onReady(onion);
+        });
     }
 
     @Override public void onClockSkewDetected(long skewSeconds) { }
@@ -141,5 +177,6 @@ public final class TorController implements TorWrapper.Observer {
     public interface OnionCallback {
         void onReady(String onionAddress);
         void onError(Exception error);
+        default void onProgress(int percentage) { }
     }
 }

--- a/app/src/main/res/drawable/ic_onion.xml
+++ b/app/src/main/res/drawable/ic_onion.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2A10,10 0,1 0,12 22A10,10 0,1 0,12 2M12,4A8,8 0,1 1,12 20A8,8 0,1 1,12 4M12,7A5,5 0,1 0,12 17A5,5 0,1 0,12 7M12,9A3,3 0,1 1,12 15A3,3 0,1 1,12 9M12,11A1,1 0,1 0,12 13A1,1 0,1 0,12 11" />
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -21,5 +21,6 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/settings_fragment_root"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>

--- a/app/src/main/res/menu/actionbar.xml
+++ b/app/src/main/res/menu/actionbar.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_onion_transfer"
-        android:icon="@drawable/pref_about"
+        android:icon="@drawable/ic_onion"
         android:title="@string/onion_transfer_title"
         app:showAsAction="ifRoom" />
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,11 +15,13 @@
     <string name="onboarding_choose_server_description">This app is an optimized client for the ErikrafT Drop and PairDrop web apps.\nChoose one of the following instances or specify a custom URL to connect to.\n\nNote: You have to choose the same URL on all devices.</string>
     <string name="onboarding_storage_permission">Storage permission</string>
     <string name="onboarding_storage_permission_description">This app is a file sharing utility. Therefore, storage permission is required order to use it.</string>
-    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop</string>
-    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop fallback</string>
-    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop fallback</string>
-    <string name="onboarding_server_quaternary_summary">(4) Quaternary — PairDrop (competitor)</string>
-    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop primary server.</string>
+    <string name="onboarding_server_primary_summary">(1) Primary — ErikrafT Drop™</string>
+    <string name="onboarding_server_secondary_summary">(2) Secondary — ErikrafT Drop™ fallback</string>
+    <string name="onboarding_server_tertiary_summary">(3) Tertiary — ErikrafT Drop™ fallback</string>
+    <string name="onboarding_server_quaternary_summary">(4) Quarto — ErikrafT Drop™ Onion Service</string>
+    <string name="onboarding_server_quinary_summary">(5) Quinto — PairDrop</string>
+    <string name="onboarding_server_onion_warning">Requer Tor. O serviço Onion é acessado diretamente pelo Tor no dispositivo.</string>
+    <string name="onboarding_server_pairdrop_summary">ErikrafT Drop™ primary server.</string>
     <string name="onboarding_server_snapdrop_summary">Simple and clean file sharing.</string>
     <string name="onboarding_server_snapdrop_summary_server_warning">PairDrop fallback.</string>
     <string name="onboarding_server_custom">Custom URL</string>
@@ -44,7 +46,7 @@
 
     <!-- Settings / About -->
     <string name="home_as_up_indicator_about">About</string>
-    <string name="title_activity_about">About ErikrafT Drop</string>
+    <string name="title_activity_about">About ErikrafT Drop™</string>
     <string name="pref_about_title">About this app</string>
     <string name="view_downloads">View downloads</string>
     <string name="pref_category_settings">Settings</string>
@@ -126,13 +128,20 @@
     <string name="resume">Resume</string>
     <string name="cancel">Cancel</string>
 
+    <!-- Onion Transfer -->
     <string name="onion_transfer_title">Transferência via Onion (Beta)</string>
+    <string name="onion_transfer_description">Compartilhe arquivos ou texto diretamente do seu dispositivo usando uma conexão privada do Tor. O conteúdo fica no seu aparelho e é entregue pelo endereço Onion temporário.</string>
     <string name="onion_transfer_select_files">Selecionar arquivos</string>
+    <string name="onion_transfer_send_text">Enviar texto</string>
+    <string name="onion_transfer_text_hint">Digite o texto que deseja compartilhar</string>
     <string name="onion_transfer_start">Iniciar Onion Service</string>
     <string name="onion_transfer_stop">Parar</string>
-    <string name="onion_transfer_waiting">Iniciando Tor e publicando Onion Service…</string>
-    <string name="onion_transfer_ready">Compartilhe este endereço Onion:</string>
+    <string name="onion_transfer_waiting">Iniciando Tor e publicando o Onion Service…</string>
+    <string name="onion_transfer_ready">Seu endereço Onion temporário:</string>
     <string name="onion_transfer_copy">Copiar link</string>
     <string name="onion_transfer_share">Compartilhar</string>
-    <string name="onion_transfer_no_files">Selecione pelo menos um arquivo.</string>
+    <string name="onion_transfer_no_files">Selecione pelo menos um arquivo ou envie um texto.</string>
+    <string name="onion_transfer_progress">Inicializando Tor… %1$d%%</string>
+    <string name="onion_transfer_server_ready">Servidor local pronto. Conectando ao Tor…</string>
+    <string name="onion_transfer_error">Não foi possível iniciar o Onion Service.</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR prepares ErikrafT Drop™ for Android 10.1.1 and fixes the Android/WebView issues requested for the Animated QR, About and Onion workflows.

### WebView / scrolling / refresh protection
- Adds a native Android clipboard bridge for `qr-send-text-paste-btn`, without opening an external Android UI.
- Bridges the Animated QR “Não desligar tela” control to the native Android window.
- Disables the native `SwipeRefreshLayout` while WebView dialogs are open, preventing pull-to-refresh from fighting with internal scrolling in Animated QR, Public Room, Pair Device and chat overlays.
- Keeps dialog scrolling touch-friendly through the companion web changes in `erikraft/Drop`.
- The Android About screen is opened through the native action bar instead of the WebView header button; while About is active, `dialogVisible` prevents `refreshWebsite()` from reloading the page accidentally and the existing back-navigation returns to the main WebView.

### Settings
- Fixes the `FragmentContainerView` height in `activity_settings.xml` so Settings child screens, including About, receive the available height instead of being collapsed by `wrap_content`.

### Onion Service
- Reworks the Onion Transfer screen into a Material-style, scrollable UI with a proper back button.
- Adds file + text sharing from the device.
- Adds working copy/share actions, QR display and a Tor bootstrap progress bar.
- Surfaces Tor startup errors instead of leaving the UI indefinitely at “Iniciando Tor…”.
- Keeps the existing local NanoHTTPD server and Briar Tor dependencies.
- Adds a dedicated Onion icon.

### Server selection / branding
- Removes the duplicate `.onion` server entry.
- Makes the Onion service `(4) Quarto` and `pairdrop.net` `(5) Quinto` permanently.
- Uses `ErikrafT Drop™` in user-facing strings while keeping technical identifiers and filenames unchanged.

### Release
- Bumps Android version to `10.1.1` / version code `24`.
- Leaves the existing `Signed APK + AAB Release Pipeline` signing/build architecture intact.

The signing pipeline and signing credentials are intentionally untouched.