### PR TITLE
Harden Tor callback lifecycle and WebView downloads

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,9 +8,10 @@
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep methods invoked by WebView's reflection-based JavaScript bridge in release builds.
+-keepclassmembers class com.erikraft.drop.JavaScriptInterface {
+    @android.webkit.JavascriptInterface <methods>;
+}
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.

--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -231,20 +231,28 @@ try {
                 const response = await fetch(href, { credentials: 'include' });
                 if (!response.ok) throw new Error('HTTP ' + response.status);
                 const blob = await response.blob();
-                const reader = new FileReader();
-                reader.onloadend = () => {
-                    const result = String(reader.result || '');
-                    const separator = result.indexOf(',');
-                    const base64 = separator >= 0 ? result.substring(separator + 1) : result;
-                    androidDownloadBridge.downloadBase64File(
-                        anchor.getAttribute('download') || 'download',
-                        blob.type || 'application/octet-stream',
-                        base64
-                    );
-                };
-                reader.readAsDataURL(blob);
+                // Keep each bridge call bounded. Passing an entire Blob as one Base64 string can
+                // exceed a WebView binder/heap limit and makes large WebTorrent downloads fail.
+                const name = anchor.getAttribute('download') || 'download';
+                const mime = blob.type || 'application/octet-stream';
+                const chunkSize = 192 * 1024; // Base64 is about 256 KiB per bridge invocation.
+                androidDownloadBridge.newFile(name, mime, String(blob.size));
+                for (let offset = 0; offset < blob.size; offset += chunkSize) {
+                    const buffer = await blob.slice(offset, offset + chunkSize).arrayBuffer();
+                    const bytes = new Uint8Array(buffer);
+                    let binary = '';
+                    for (let index = 0; index < bytes.length; index += 0x8000) {
+                        binary += String.fromCharCode.apply(null, bytes.subarray(index, index + 0x8000));
+                    }
+                    androidDownloadBridge.onBytes(btoa(binary));
+                }
+                androidDownloadBridge.saveDownloadFileName(name, String(blob.size));
                 return true;
             } catch (error) {
+                // Discard a partially written file if a chunk conversion or native write fails.
+                if (typeof androidDownloadBridge.ignoreClickedListener === 'function') {
+                    androidDownloadBridge.ignoreClickedListener();
+                }
                 console.error('Android WebView download bridge failed', error);
                 return false;
             }

--- a/app/src/main/java/com/erikraft/drop/CallbackGeneration.java
+++ b/app/src/main/java/com/erikraft/drop/CallbackGeneration.java
@@ -1,0 +1,24 @@
+package com.erikraft.drop;
+
+/**
+ * Invalidates asynchronous work belonging to an older controller operation.
+ *
+ * <p>Tor wrapper observers and Activity callbacks can be delivered after a retry or shutdown.
+ * A callback must therefore be associated with the wrapper/request that created it, rather than
+ * merely with the controller singleton.</p>
+ */
+final class CallbackGeneration {
+    private long value;
+
+    synchronized long next() {
+        return ++value;
+    }
+
+    synchronized boolean isCurrent(final long generation) {
+        return value == generation;
+    }
+
+    synchronized long current() {
+        return value;
+    }
+}

--- a/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
+++ b/app/src/main/java/com/erikraft/drop/JavaScriptInterface.java
@@ -50,8 +50,9 @@ public class JavaScriptInterface {
     @JavascriptInterface
     public synchronized void newFile(final String fileName, final String mimeType, final String fileSize) throws IOException {
         Log.i("DropAndroidJS", "Transfer Start: Receiving file. fileName=" + fileName + ", mimeType=" + mimeType + ", fileSize=" + fileSize);
-        String finalMime = mimeType;
-        if (mimeType.startsWith("base64:")) finalMime = mimeType.substring(7);
+        final String safeName = sanitizeDownloadName(fileName);
+        String finalMime = TextUtils.isEmpty(mimeType) ? "application/octet-stream" : mimeType;
+        if (finalMime.startsWith("base64:")) finalMime = finalMime.substring(7);
 
         IOUtils.closeStreamQuietly(fileOutputStream);
         fileOutputStream = null;
@@ -60,11 +61,11 @@ public class JavaScriptInterface {
         expectedBytes = parseExpectedBytes(fileSize);
         transferActive = false;
 
-        final FileWrapper fileWrapper = createFileWrapper(fileName, finalMime);
+        final FileWrapper fileWrapper = createFileWrapper(safeName, finalMime);
         if (fileWrapper == null) throw new IOException("Missing storage permissions");
         fileOutputStream = UriUtils.openOutputStream(fileWrapper.getUri(), context.getApplicationContext());
         if (fileOutputStream == null) throw new IOException("Cannot write target file");
-        fileHeader = new FileHeader(fileName, finalMime, fileSize, fileWrapper);
+        fileHeader = new FileHeader(safeName, finalMime, fileSize, fileWrapper);
         try {
             messageDigest = java.security.MessageDigest.getInstance("SHA-256");
         } catch (java.security.NoSuchAlgorithmException e) {

--- a/app/src/main/java/com/erikraft/drop/TorController.java
+++ b/app/src/main/java/com/erikraft/drop/TorController.java
@@ -19,6 +19,8 @@ import org.briarproject.onionwrapper.TorWrapper;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
@@ -39,10 +41,11 @@ public final class TorController {
     private volatile AndroidTorWrapper tor;
     private volatile int socksPort;
     private volatile int controlPort;
-    private volatile long torGeneration;
+    private final CallbackGeneration torGeneration = new CallbackGeneration();
+    private final CallbackGeneration onionGeneration = new CallbackGeneration();
     private volatile boolean started;
     private volatile boolean connected;
-    private volatile Runnable pendingConnected;
+    private final List<Runnable> pendingConnected = new ArrayList<>();
     private volatile OnionCallback pendingOnion;
 
     private TorController(@NonNull Context context) {
@@ -86,12 +89,12 @@ public final class TorController {
         int[] ports = findAvailablePortPair();
         socksPort = ports[0];
         controlPort = ports[1];
-        final long generation = ++torGeneration;
+        final long generation = torGeneration.next();
         AndroidTorWrapper newTor = new AndroidTorWrapper(application, wakeLockManager, ioExecutor, mainExecutor, architecture(),
                 application.getDir("tor", Context.MODE_PRIVATE), socksPort, controlPort);
         newTor.setObserver(new TorWrapper.Observer() {
             private boolean isCurrent() {
-                return generation == torGeneration;
+                return torGeneration.isCurrent(generation);
             }
 
             @Override
@@ -155,12 +158,12 @@ public final class TorController {
         });
     }
 
-    public void start(Runnable callback) {
+    public synchronized void start(Runnable callback) {
         if (connected) {
             mainExecutor.execute(callback);
             return;
         }
-        pendingConnected = callback;
+        pendingConnected.add(callback);
         if (started) return;
         started = true;
         executor.execute(this::startTorWithRetry);
@@ -193,34 +196,46 @@ public final class TorController {
         failPending(lastError);
     }
 
-    private void failPending(final Exception error) {
-        pendingConnected = null;
+    private synchronized void failPending(final Exception error) {
+        pendingConnected.clear();
+        onionGeneration.next();
+        final long failureGeneration = onionGeneration.current();
         final OnionCallback callback = pendingOnion;
         pendingOnion = null;
-        if (callback != null) mainExecutor.execute(() -> callback.onError(error));
+        if (callback != null) mainExecutor.execute(() -> {
+            if (onionGeneration.isCurrent(failureGeneration)) callback.onError(error);
+        });
     }
 
-    public void publishHiddenService(int localPort, OnionCallback callback) {
+    public synchronized void publishHiddenService(int localPort, OnionCallback callback) {
+        final long requestGeneration = onionGeneration.next();
         pendingOnion = callback;
         callback.onProgress(0);
         start(() -> executor.execute(() -> {
             try {
+                if (!onionGeneration.isCurrent(requestGeneration)) return;
                 callback.onProgress(80);
-                tor.publishHiddenService(localPort, 80, null);
+                final AndroidTorWrapper currentTor = tor;
+                currentTor.publishHiddenService(localPort, 80, null);
             } catch (Exception e) {
-                pendingOnion = null;
+                if (!onionGeneration.isCurrent(requestGeneration)) return;
+                synchronized (TorController.this) {
+                    if (onionGeneration.isCurrent(requestGeneration)) pendingOnion = null;
+                }
                 Log.e(TAG, "Unable to publish Onion service", e);
-                mainExecutor.execute(() -> callback.onError(e));
+                mainExecutor.execute(() -> {
+                    if (onionGeneration.isCurrent(requestGeneration)) callback.onError(e);
+                });
             }
         }));
     }
 
-    private void handleState(TorWrapper.TorState state) {
+    private synchronized void handleState(TorWrapper.TorState state) {
         if (state == TorWrapper.TorState.CONNECTED) {
             connected = true;
-            Runnable cb = pendingConnected;
-            pendingConnected = null;
-            if (cb != null) mainExecutor.execute(cb);
+            final List<Runnable> callbacks = new ArrayList<>(pendingConnected);
+            pendingConnected.clear();
+            for (Runnable callback : callbacks) mainExecutor.execute(callback);
         } else if (state == TorWrapper.TorState.STOPPED) {
             connected = false;
             started = false;
@@ -228,14 +243,19 @@ public final class TorController {
     }
 
     private void handleBootstrapPercentage(int percentage) {
+        final long requestGeneration = onionGeneration.current();
         final OnionCallback callback = pendingOnion;
-        if (callback != null) mainExecutor.execute(() -> callback.onProgress(Math.max(0, Math.min(100, percentage))));
+        if (callback != null) mainExecutor.execute(() -> {
+            if (onionGeneration.isCurrent(requestGeneration)) callback.onProgress(Math.max(0, Math.min(100, percentage)));
+        });
     }
 
     private void handleHsDescriptorUpload(String onion) {
+        final long requestGeneration = onionGeneration.current();
         OnionCallback cb = pendingOnion;
         pendingOnion = null;
         if (cb != null) mainExecutor.execute(() -> {
+            if (!onionGeneration.isCurrent(requestGeneration)) return;
             cb.onProgress(100);
             cb.onReady(onion);
         });
@@ -245,7 +265,10 @@ public final class TorController {
 
     public static synchronized void shutdown(@NonNull Context context) {
         if (instance == null) return;
-        instance.torGeneration++;
+        instance.torGeneration.next();
+        instance.onionGeneration.next();
+        instance.pendingConnected.clear();
+        instance.pendingOnion = null;
         try { instance.tor.stop(); } catch (Exception ignored) { }
         if (WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
             ProxyController.getInstance().clearProxyOverride(instance.mainExecutor, () -> { });

--- a/app/src/test/java/com/erikraft/drop/CallbackGenerationTest.java
+++ b/app/src/test/java/com/erikraft/drop/CallbackGenerationTest.java
@@ -1,0 +1,27 @@
+package com.erikraft.drop;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CallbackGenerationTest {
+    @Test
+    public void retryInvalidatesCallbacksFromThePreviousWrapper() {
+        final CallbackGeneration generations = new CallbackGeneration();
+        final long oldWrapper = generations.next();
+        final long newWrapper = generations.next();
+
+        assertFalse(generations.isCurrent(oldWrapper));
+        assertTrue(generations.isCurrent(newWrapper));
+    }
+
+    @Test
+    public void shutdownInvalidatesCallbacksAlreadyQueuedOnTheMainThread() {
+        final CallbackGeneration generations = new CallbackGeneration();
+        final long request = generations.next();
+        generations.next();
+
+        assertFalse(generations.isCurrent(request));
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent stale callbacks from an old Tor wrapper or onion request from mutating state of a newly created wrapper after retries/shutdown, and avoid lost continuations when multiple callers request Tor start concurrently.
- Avoid huge single-base64 payloads crossing the WebView bridge (which fail for large WebTorrent/blob downloads) by streaming data in bounded chunks into the existing native bridge.
- Preserve JavaScript bridge methods during R8/ProGuard minification and harden filename/mime handling for bridge-initiated downloads.

### Description
- Introduced `CallbackGeneration` to issue generation tokens and invalidate old asynchronous work associated with previous wrapper or onion requests.
- Reworked `TorController` to use generation tokens for the wrapper and onion operations, queue multiple `start()` continuations, synchronize access to pending lists, and ensure `shutdown()` invalidates queued/generated callbacks so stale observers cannot affect new state.
- Replaced the single-blob Base64 download path in `app/src/main/assets/init.js` with a streaming approach that calls `newFile(name,mime,size)`, repeated `onBytes(base64Chunk)`, then `saveDownloadFileName(name,size)`, and calls `ignoreClickedListener()` on error to clean up partial files.
- Hardened `JavaScriptInterface.newFile(...)` to sanitize filenames and provide a safe default MIME, and ensured existing chunked receipt (`onBytes`, `saveDownloadFileName`) writes to SAF/MediaStore or temp files as before while computing SHA-256 for diagnostics.
- Added a ProGuard rule to keep `@JavascriptInterface` methods in `JavaScriptInterface` for release builds.
- Added unit tests for the generation helper in `app/src/test/java/com/erikraft/drop/CallbackGenerationTest.java`.
- Files changed: `TorController.java`, `CallbackGeneration.java` (new), `CallbackGenerationTest.java` (new), `init.js`, `JavaScriptInterface.java`, `proguard-rules.pro`.

### Testing
- `git diff --check` passed with no whitespace errors.
- `node --check app/src/main/assets/init.js` passed, confirming JS syntax.
- `javac` compiled the new `CallbackGeneration` helper successfully.
- Node-based chunked Base64 checksum tests validated byte-for-byte reassembly for empty, small text, Unicode-named, 512 KiB, ~1 MiB, and 8 MiB payloads, verifying the chunking/concatenation logic.
- `./gradlew checkstyle` completed successfully (project lint/test/assemble tasks requiring Android SDK were not executed because no SDK is configured in this environment).
- `./gradlew clean test`, `./gradlew lint`, and `./gradlew assembleDebug` could not run due to a missing Android SDK (`ANDROID_HOME`/`sdk.dir` not set) and `adb` was not available, so on-device Tor/WebView/MediaStore behavior was not validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2d06bf734832aaac1da9a09289682)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download reliability by processing large files in smaller chunks, reducing memory usage.
  - Prevented incomplete files from being retained when a download fails.
  - Sanitized downloaded filenames and applied a standard fallback MIME type when needed.
  - Improved connection and hidden-service callback handling to avoid stale or missed status updates.
- **Security**
  - Preserved JavaScript bridge methods required for reliable WebView download integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->